### PR TITLE
Split inference rules

### DIFF
--- a/packages/typir/src/typir.ts
+++ b/packages/typir/src/typir.ts
@@ -29,6 +29,9 @@ import { Kind } from './kinds/kind.js';
  * - realize "unknown" as a generic "<T = unknown>" for whole Typir? for the Langium binding T would be AstNode!
  * - Is it easy to use two different Typir instances side-by-side within the same application?
  * - How to bundle Typir configurations for reuse ("presets")?
+ * - How to handle cycles?
+ *     - Cycles at types: MyClass { myField?: MyClass, myFunction(operand: MyClass) }, MyClass<T extends MyClass<T>> to return typed sub-class instances
+ *     - Cycles at instances/objects: Parent used as Child?!
  */
 
 /** TODO missing things

--- a/packages/typir/test/type-definitions.test.ts
+++ b/packages/typir/test/type-definitions.test.ts
@@ -65,13 +65,21 @@ describe('Tests for Typir', () => {
         const opMinus = typir.operators.createBinaryOperator({ name: '-', inputType: typeInt });
         const opLess = typir.operators.createBinaryOperator({ name: '<', inputType: typeInt, outputType: typeBoolean });
         const opEqualInt = typir.operators.createBinaryOperator({ name: '==', inputType: typeInt, outputType: typeBoolean,
-            inferenceRule: domainElement => ('' + domainElement).includes('==') });
+            inferenceRule: {
+                filter: (domainElement): domainElement is string => typeof domainElement === 'string',
+                matching: domainElement => domainElement.includes('=='),
+                operands: domainElement => []
+            }});
         // binary operators on Booleans
         const opEqualBool = typir.operators.createBinaryOperator({ name: '==', inputType: typeBoolean});
         const opAnd = typir.operators.createBinaryOperator({ name: '&&', inputType: typeBoolean});
         // unary operators
         const opNotBool = typir.operators.createUnaryOperator({ name: '!', operandType: typeBoolean,
-            inferenceRule: domainElement => ('' + domainElement).includes('NOT')});
+            inferenceRule: {
+                filter: (domainElement): domainElement is string => typeof domainElement === 'string',
+                matching: domainElement => domainElement.includes('NOT'),
+                operand: domainElement => []
+            }});
         // ternary operator
         const opTernaryIf = typir.operators.createTernaryOperator({ name: 'if', firstType: typeBoolean, secondAndThirdType: typeInt}); // TODO support multiple/arbitrary types!
 


### PR DESCRIPTION
Contributes a refactoring for inference rules of operators and functions:
- split the responsibilities in individual properties (checking the current element VS get its children/operands)
- might be a bit less compact
- developed the idea together with @Lotes