### PR TITLE
Use type inference during type definition, customizable validation messages

### DIFF
--- a/examples/lox/test/lox-type-checking.test.ts
+++ b/examples/lox/test/lox-type-checking.test.ts
@@ -93,7 +93,7 @@ describe('Explicitly test type checking for LOX', () => {
         `, 0, 1);
     });
 
-    test('Class inheritance', async () => {
+    test('Class inheritance for assignments', async () => {
         await validate(`
             class MyClass1 { name: string age: number }
             class MyClass2 < MyClass1 {}
@@ -104,6 +104,19 @@ describe('Explicitly test type checking for LOX', () => {
             class MyClass2 < MyClass1 {}
             var v1: MyClass2 = MyClass1();
         `, 1);
+    });
+
+    test.fails('Class inheritance and the order of type definitions', async () => {
+        // the "normal" case: 1st super class, 2nd sub class
+        await validate(`
+            class MyClass1 {}
+            class MyClass2 < MyClass1 {}
+        `, 0);
+        // switching the order of super and sub class works in Langium, but not in Typir at the moment
+        await validate(`
+            class MyClass2 < MyClass1 {}
+            class MyClass1 {}
+        `, 0);
     });
 
     test('Class fields', async () => {

--- a/examples/ox/src/language/ox-type-checking.ts
+++ b/examples/ox/src/language/ox-type-checking.ts
@@ -95,7 +95,16 @@ export function createTypir(domainNodeEntry: AstNode): Typir {
         }
     });
 
-    // TODO fix order, since the function types already use type inference and therefore might need the following additional inference rules
+    /** Hints regarding the order of Typir configurations for OX:
+     * - In general, Typir aims to not depend on the order of configurations.
+     *   (Beyond some obvious things, e.g. created Type instances can be used only afterwards and not before their creation.)
+     * - But at the moment, this objective is not reached in general!
+     * - As an example, since the function definition above uses type inference for their parameter types, it is necessary,
+     *   that the primitive types and their corresponding inference rules are defined earlier!
+     * - In the future, the user of Typir will not need to do a topological sorting of type definitions anymore,
+     *   since the type definition process will be split and parts will be delayed.
+     * - The following inference rules are OK, since they are not relevant for defining function types
+     */
 
     // additional inference rules ...
     typir.inference.addInferenceRule((domainElement: unknown) => {

--- a/packages/typir/src/features/assignability.ts
+++ b/packages/typir/src/features/assignability.ts
@@ -6,7 +6,7 @@
 
 import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem } from '../utils/utils-type-comparison.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
 
 export interface AssignabilityProblem {
     source: Type;

--- a/packages/typir/src/features/assignability.ts
+++ b/packages/typir/src/features/assignability.ts
@@ -36,7 +36,7 @@ export class DefaultTypeAssignability implements TypeAssignability {
 
     getAssignabilityProblem(source: Type, target: Type): AssignabilityProblem | undefined {
         // conversion possible?
-        if (this.typir.conversion.isConvertibleTo(source, target, 'IMPLICIT')) {
+        if (this.typir.conversion.isConvertible(source, target, 'IMPLICIT')) {
             return undefined;
         }
 

--- a/packages/typir/src/features/equality.ts
+++ b/packages/typir/src/features/equality.ts
@@ -7,8 +7,9 @@
 import { assertUnreachable } from 'langium';
 import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem, checkValueForConflict } from '../utils/utils-type-comparison.js';
+import { checkValueForConflict } from '../utils/utils-type-comparison.js';
 import { RelationshipKind, TypeRelationshipCaching } from './caching.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
 
 export interface TypeEqualityProblem {
     type1: Type;

--- a/packages/typir/src/features/inference.ts
+++ b/packages/typir/src/features/inference.ts
@@ -6,7 +6,7 @@
 
 import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem } from '../utils/utils-type-comparison.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
 
 export interface InferenceProblem {
     domainElement: unknown;

--- a/packages/typir/src/features/operator.ts
+++ b/packages/typir/src/features/operator.ts
@@ -7,7 +7,8 @@
 import { Type } from '../graph/type-node.js';
 import { FUNCTION_MISSING_NAME, FunctionKind, FunctionKindName, isFunctionKind } from '../kinds/function-kind.js';
 import { Typir } from '../typir.js';
-import { NameTypePair, Types, toArray } from '../utils/utils.js';
+import { NameTypePair, Types } from '../utils/utils-definitions.js';
+import { toArray } from '../utils/utils.js';
 
 // export type InferOperatorWithSingleOperand = (domainElement: unknown, operatorName: string) => boolean | unknown;
 export type InferOperatorWithSingleOperand<T = unknown> = {

--- a/packages/typir/src/features/printing.ts
+++ b/packages/typir/src/features/printing.ts
@@ -7,13 +7,14 @@
 import { assertUnreachable } from 'langium';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { IndexedTypeConflict, TypirProblem, ValueConflict, isIndexedTypeConflict, isValueConflict } from '../utils/utils-type-comparison.js';
+import { IndexedTypeConflict, ValueConflict, isIndexedTypeConflict, isValueConflict } from '../utils/utils-type-comparison.js';
 import { toArray } from '../utils/utils.js';
 import { AssignabilityProblem, isAssignabilityProblem } from './assignability.js';
 import { TypeEqualityProblem, isTypeEqualityProblem } from './equality.js';
 import { InferenceProblem, isInferenceProblem } from './inference.js';
 import { SubTypeProblem, isSubTypeProblem } from './subtype.js';
 import { ValidationProblem, isValidationProblem } from './validation.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
 
 export interface ProblemPrinter {
     printValueConflict(problem: ValueConflict): string;

--- a/packages/typir/src/features/printing.ts
+++ b/packages/typir/src/features/printing.ts
@@ -28,6 +28,7 @@ export interface ProblemPrinter {
     printTypirProblem(problem: TypirProblem): string;
     printTypirProblems(problems: TypirProblem[]): string;
 
+    printDomainElement(domainElement: unknown, sentenceBegin: boolean): string;
     printType(type: Type): string;
 }
 
@@ -142,7 +143,7 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
         return problems.map(p => this.printTypirProblem(p, level)).join('\n');
     }
 
-    protected printDomainElement(domainElement: unknown, sentenceBegin: boolean = false): string {
+    printDomainElement(domainElement: unknown, sentenceBegin: boolean = false): string {
         return `${sentenceBegin ? 'T' : 't'}he domain element '${domainElement}'`;
     }
 

--- a/packages/typir/src/features/subtype.ts
+++ b/packages/typir/src/features/subtype.ts
@@ -7,8 +7,8 @@
 import { assertUnreachable } from 'langium';
 import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem } from '../utils/utils-type-comparison.js';
 import { RelationshipKind, TypeRelationshipCaching } from './caching.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
 
 export interface SubTypeProblem {
     // 'undefined' means type or information is missing, 'string' is for data which are no Types

--- a/packages/typir/src/features/validation.ts
+++ b/packages/typir/src/features/validation.ts
@@ -6,9 +6,11 @@
 
 import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypeCheckStrategy, TypirProblem, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
+import { TypeCheckStrategy, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
 
 export type Severity = 'error' | 'warning' | 'info' | 'hint';
+
 export interface ValidationProblem {
     domainElement: unknown;
     domainProperty?: string; // name of a property of the domain element; TODO make this type-safe!

--- a/packages/typir/src/index.ts
+++ b/packages/typir/src/index.ts
@@ -24,4 +24,5 @@ export * from './kinds/multiplicity-kind.js';
 export * from './kinds/primitive-kind.js';
 export * from './kinds/top-kind.js';
 export * from './utils/utils.js';
+export * from './utils/utils-definitions.js';
 export * from './utils/utils-type-comparison.js';

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -10,9 +10,10 @@ import { SubTypeProblem } from '../features/subtype.js';
 import { TypeEdge } from '../graph/type-edge.js';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { IndexedTypeConflict, MapListConverter, TypeCheckStrategy, TypirProblem, checkNameTypesMap, checkValueForConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
-import { NameTypePair, assertKind, assertTrue, toArray } from '../utils/utils.js';
+import { IndexedTypeConflict, MapListConverter, TypeCheckStrategy, checkNameTypesMap, checkValueForConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
+import { assertKind, assertTrue, toArray } from '../utils/utils.js';
 import { Kind, isKind } from './kind.js';
+import { NameTypePair, TypirProblem } from '../utils/utils-definitions.js';
 
 export interface ClassKindOptions {
     typing: 'Structural' | 'Nominal', // JS classes are nominal, TS structures are structural

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -13,7 +13,7 @@ import { Typir } from '../typir.js';
 import { IndexedTypeConflict, MapListConverter, TypeCheckStrategy, checkNameTypesMap, checkValueForConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
 import { assertKind, assertTrue, toArray } from '../utils/utils.js';
 import { Kind, isKind } from './kind.js';
-import { NameTypePair, TypirProblem } from '../utils/utils-definitions.js';
+import { resolveTypeSelector, TypeSelector, TypirProblem } from '../utils/utils-definitions.js';
 
 export interface ClassKindOptions {
     typing: 'Structural' | 'Nominal', // JS classes are nominal, TS structures are structural
@@ -26,10 +26,15 @@ export interface ClassKindOptions {
 
 export const ClassKindName = 'ClassKind';
 
+export interface FieldDetails {
+    name: string;
+    type: TypeSelector;
+}
+
 export interface ClassTypeDetails<T1 = unknown, T2 = unknown> { // TODO the generics look very bad!
     className: string,
-    superClasses?: Type | Type[],
-    fields: NameTypePair[],
+    superClasses?: TypeSelector | TypeSelector[],
+    fields: FieldDetails[],
     // TODO methods
     inferenceRuleForDeclaration?: (domainElement: unknown) => boolean, // TODO what is the purpose for this? what is the difference to literals?
     inferenceRuleForLiteral?: InferClassLiteral<T1>, // InferClassLiteral<T> | Array<InferClassLiteral<T>>, does not work: https://stackoverflow.com/questions/65129070/defining-an-array-of-differing-generic-types-in-typescript
@@ -99,7 +104,8 @@ export class ClassKind implements Kind {
         // link it to all its "field types"
         for (const fieldInfos of typeDetails.fields) {
             // new edge between class and field with "semantics key"
-            const edge = new TypeEdge(classType, fieldInfos.type, FIELD_TYPE);
+            const fieldType = resolveTypeSelector(this.typir, fieldInfos.type);
+            const edge = new TypeEdge(classType, fieldType, FIELD_TYPE);
             // store the name of the field within the edge
             edge.properties.set(FIELD_NAME, fieldInfos.name);
             this.typir.graph.addEdge(edge);
@@ -117,17 +123,19 @@ export class ClassKind implements Kind {
             }
         }
         // check cycles
-        for (const superClass of theSuperClasses) {
+        for (const superDetails of theSuperClasses) {
+            const superClass = resolveTypeSelector(this.typir, superDetails);
             if (this.getAllSuperClasses(superClass, true).has(classType)) {
                 throw new Error('Circle in super-sub-class-relationships are not allowed.');
             }
         }
         // link the new class to all its super classes
-        for (const superr of theSuperClasses) {
-            if (superr.kind.$name !== classType.kind.$name) {
+        for (const superDetails of theSuperClasses) {
+            const superClass = resolveTypeSelector(this.typir, superDetails);
+            if (superClass.kind.$name !== classType.kind.$name) {
                 throw new Error();
             }
-            const edge = new TypeEdge(classType, superr, SUPER_CLASS);
+            const edge = new TypeEdge(classType, superClass, SUPER_CLASS);
             this.typir.graph.addEdge(edge);
         }
 
@@ -234,11 +242,11 @@ export class ClassKind implements Kind {
         if (this.options.typing === 'Structural') {
             // fields
             const fields: string[] = [];
-            for (const field of typeDetails.fields.entries()) {
-                fields.push(`${field[0]}:${field[1].name}`);
+            for (const [fieldNUmber, fieldDetails] of typeDetails.fields.entries()) {
+                fields.push(`${fieldNUmber}:${fieldDetails.name}`);
             }
             // super classes
-            const superClasses = toArray(typeDetails.superClasses);
+            const superClasses = toArray(typeDetails.superClasses).map(selector => resolveTypeSelector(this.typir, selector));
             const extendedClasses = superClasses.length <= 0 ? '' : `-extends-${superClasses.map(c => c.name).join(',')}`;
             // whole representation
             return `${prefix}-${typeDetails.className}{${fields.join(',')}}${extendedClasses}`;

--- a/packages/typir/src/kinds/fixed-parameters-kind.ts
+++ b/packages/typir/src/kinds/fixed-parameters-kind.ts
@@ -8,7 +8,8 @@ import { SubTypeProblem } from '../features/subtype.js';
 import { TypeEdge } from '../graph/type-edge.js';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypeCheckStrategy, TypirProblem, checkTypes, checkValueForConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
+import { TypeCheckStrategy, checkTypes, checkValueForConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
 import { assertKind, assertTrue, toArray } from '../utils/utils.js';
 import { Kind, isKind } from './kind.js';
 

--- a/packages/typir/src/kinds/function-kind.ts
+++ b/packages/typir/src/kinds/function-kind.ts
@@ -10,8 +10,9 @@ import { DefaultValidationCollector, ValidationCollector, ValidationProblem } fr
 import { TypeEdge } from '../graph/type-edge.js';
 import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem, checkNameTypePair, checkNameTypePairs, checkTypes, checkValueForConflict } from '../utils/utils-type-comparison.js';
-import { assertKind, NameTypePair } from '../utils/utils.js';
+import { NameTypePair, resolveTypeSelector, TypeSelector, TypirProblem } from '../utils/utils-definitions.js';
+import { checkNameTypePair, checkNameTypePairs, checkTypes, checkValueForConflict } from '../utils/utils-type-comparison.js';
+import { assertKind, assertTrue } from '../utils/utils.js';
 import { Kind, isKind } from './kind.js';
 
 export interface FunctionKindOptions {

--- a/packages/typir/src/kinds/kind.ts
+++ b/packages/typir/src/kinds/kind.ts
@@ -5,7 +5,7 @@
  ******************************************************************************/
 
 import { Type } from '../graph/type-node.js';
-import { TypirProblem } from '../utils/utils-type-comparison.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
 
 /**
  * Typir provides a default set of Kinds, e.g. primitive types and class types.

--- a/packages/typir/src/kinds/multiplicity-kind.ts
+++ b/packages/typir/src/kinds/multiplicity-kind.ts
@@ -8,7 +8,8 @@ import { SubTypeProblem } from '../features/subtype.js';
 import { TypeEdge } from '../graph/type-edge.js';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem, checkValueForConflict } from '../utils/utils-type-comparison.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
+import { checkValueForConflict } from '../utils/utils-type-comparison.js';
 import { assertKind } from '../utils/utils.js';
 import { Kind, isKind } from './kind.js';
 

--- a/packages/typir/src/kinds/primitive-kind.ts
+++ b/packages/typir/src/kinds/primitive-kind.ts
@@ -8,7 +8,8 @@ import { InferenceRuleNotApplicable } from '../features/inference.js';
 import { SubTypeProblem } from '../features/subtype.js';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem, checkValueForConflict } from '../utils/utils-type-comparison.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
+import { checkValueForConflict } from '../utils/utils-type-comparison.js';
 import { assertKind, toArray } from '../utils/utils.js';
 import { Kind, isKind } from './kind.js';
 

--- a/packages/typir/src/kinds/top-kind.ts
+++ b/packages/typir/src/kinds/top-kind.ts
@@ -8,7 +8,8 @@ import { InferenceRuleNotApplicable } from '../features/inference.js';
 import { SubTypeProblem } from '../features/subtype.js';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem, checkValueForConflict } from '../utils/utils-type-comparison.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
+import { checkValueForConflict } from '../utils/utils-type-comparison.js';
 import { assertKind, toArray } from '../utils/utils.js';
 import { Kind, isKind } from './kind.js';
 

--- a/packages/typir/src/utils/utils-definitions.ts
+++ b/packages/typir/src/utils/utils-definitions.ts
@@ -1,0 +1,23 @@
+/******************************************************************************
+ * Copyright 2024 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { AssignabilityProblem } from '../features/assignability.js';
+import { TypeEqualityProblem } from '../features/equality.js';
+import { InferenceProblem } from '../features/inference.js';
+import { SubTypeProblem } from '../features/subtype.js';
+import { ValidationProblem } from '../features/validation.js';
+import { Type } from '../graph/type-node.js';
+import { IndexedTypeConflict, ValueConflict } from './utils-type-comparison.js';
+
+export type TypirProblem = ValueConflict | IndexedTypeConflict | AssignabilityProblem | SubTypeProblem | TypeEqualityProblem | InferenceProblem | ValidationProblem;
+
+export type Types = Type | Type[];
+export type Names = string | string[];
+
+export type NameTypePair = {
+    name: string;
+    type: Type;
+}

--- a/packages/typir/src/utils/utils-definitions.ts
+++ b/packages/typir/src/utils/utils-definitions.ts
@@ -60,7 +60,7 @@ export function resolveTypeSelector(typir: Typir, selector: TypeSelector): Type 
         if (isType(result)) {
             return result;
         } else {
-            throw new Error('TODO handle inference problem');
+            throw new Error('TODO handle inference problem for ' + typir.printer.printDomainElement(selector, false));
         }
     }
 }

--- a/packages/typir/src/utils/utils-definitions.ts
+++ b/packages/typir/src/utils/utils-definitions.ts
@@ -23,14 +23,21 @@ export type NameTypePair = {
     type: Type;
 }
 
+// TODO this is a WIP sketch for managing the use of Types in properties/details of other Types (e.g. Types of fields of class Types)
 export interface TypeReference<T extends Type = Type> {
     readonly ref?: T;
     readonly selector?: TypeSelector;
     readonly error?: TypirProblem;
 }
 
+// This TypeScript type defines the possible ways to identify a wanted Typir type.
 // TODO find better names
-export type TypeSelector = Type | string | unknown; // Type itself | identifier of the type (in the type graph) | node to infer the type from
+export type TypeSelector =
+    | Type      // the instance of the wanted type
+    | string    // identifier of the type (in the type graph/map)
+    | unknown   // domain node to infer the final type from
+    ;
+// TODO this is a sketch for delaying the type selection in the future
 export type DelayedTypeSelector = TypeSelector | (() => TypeSelector);
 
 export function resolveTypeSelector(typir: Typir, selector: TypeSelector): Type {

--- a/packages/typir/src/utils/utils-definitions.ts
+++ b/packages/typir/src/utils/utils-definitions.ts
@@ -9,8 +9,9 @@ import { TypeEqualityProblem } from '../features/equality.js';
 import { InferenceProblem } from '../features/inference.js';
 import { SubTypeProblem } from '../features/subtype.js';
 import { ValidationProblem } from '../features/validation.js';
-import { Type } from '../graph/type-node.js';
-import { IndexedTypeConflict, ValueConflict } from './utils-type-comparison.js';
+import { isType, Type } from '../graph/type-node.js';
+import { Typir } from '../typir.js';
+import { ValueConflict, IndexedTypeConflict } from './utils-type-comparison.js';
 
 export type TypirProblem = ValueConflict | IndexedTypeConflict | AssignabilityProblem | SubTypeProblem | TypeEqualityProblem | InferenceProblem | ValidationProblem;
 
@@ -20,4 +21,39 @@ export type Names = string | string[];
 export type NameTypePair = {
     name: string;
     type: Type;
+}
+
+export interface TypeReference<T extends Type = Type> {
+    readonly ref?: T;
+    readonly selector?: TypeSelector;
+    readonly error?: TypirProblem;
+}
+
+// TODO find better names
+export type TypeSelector = Type | string | unknown; // Type itself | identifier of the type (in the type graph) | node to infer the type from
+export type DelayedTypeSelector = TypeSelector | (() => TypeSelector);
+
+export function resolveTypeSelector(typir: Typir, selector: TypeSelector): Type {
+    /** TODO this is only a rough sketch:
+     * - detect cycles/deadlocks during the resolving process
+     * - make the resolving strategy exchangable
+     * - integrate it into TypeReference implementation?
+     */
+    if (isType(selector)) {
+        return selector;
+    } else if (typeof selector === 'string') {
+        const result = typir.graph.getType(selector);
+        if (result) {
+            return result;
+        } else {
+            throw new Error('TODO not-found problem');
+        }
+    } else {
+        const result = typir.inference.inferType(selector);
+        if (isType(result)) {
+            return result;
+        } else {
+            throw new Error('TODO handle inference problem');
+        }
+    }
 }

--- a/packages/typir/src/utils/utils-type-comparison.ts
+++ b/packages/typir/src/utils/utils-type-comparison.ts
@@ -5,14 +5,10 @@
  ******************************************************************************/
 
 import { assertUnreachable } from 'langium';
-import { AssignabilityProblem } from '../features/assignability.js';
-import { TypeEqualityProblem } from '../features/equality.js';
-import { SubTypeProblem } from '../features/subtype.js';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { NameTypePair, assertTrue } from '../utils/utils.js';
-import { InferenceProblem } from '../features/inference.js';
-import { ValidationProblem } from '../features/validation.js';
+import { assertTrue } from '../utils/utils.js';
+import { NameTypePair, TypirProblem } from './utils-definitions.js';
 
 export type TypeCheckStrategy =
     'EQUAL_TYPE' | // the most strict checking
@@ -36,8 +32,6 @@ export function createTypeCheckStrategy(strategy: TypeCheckStrategy, typir: Typi
             assertUnreachable(strategy);
     }
 }
-
-export type TypirProblem = ValueConflict | IndexedTypeConflict | AssignabilityProblem | SubTypeProblem | TypeEqualityProblem | InferenceProblem | ValidationProblem;
 
 export interface ValueConflict {
     // 'undefined' means value is missing, 'string' is the string representation of the value

--- a/packages/typir/src/utils/utils.ts
+++ b/packages/typir/src/utils/utils.ts
@@ -4,18 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { Type } from '../graph/type-node.js';
 import { Kind } from '../kinds/kind.js';
 
-export type Types = Type | Type[];
-export type Names = string | string[];
-
-export type NameTypePair = {
-    name: string;
-    type: Type;
-}
-
-export function assertTrue(condition: boolean, msg?: string) {
+export function assertTrue(condition: boolean, msg?: string): asserts condition {
     if (!condition) {
         throw new Error(msg);
     }


### PR DESCRIPTION
I added the following features in this PR:
- use type inference during type definition
    - roughly implemented only for classes (fields, super-class) and functions (parameters)
    - this shows the importance of supporting delayed type definitions, since some parts of LOX would need a topological sorting regarding the customization order
- enable Typir users to customize details of validation messages (e.g. see the LOX example for the operator `==`)
- adapted the conversion API to a proposal of Markus
- refactorings