### PR TITLE
Introduced XTypes and reworked the type graph infrastructure

### DIFF
--- a/examples/lox/src/language/type-system/lox-type-checking.ts
+++ b/examples/lox/src/language/type-system/lox-type-checking.ts
@@ -228,19 +228,19 @@ export function createTypir(domainNodeEntry: AstNode): Typir {
                     ...typir.validation.constraints.ensureNodeHasNotType(node, typeVoid,
                         () => <ValidationMessageDetails>{ message: "Variable can't be declared with a type 'void'.", domainProperty: 'type' }),
                     ...typir.validation.constraints.ensureNodeIsAssignable(node.value, node, (actual, expected) => <ValidationMessageDetails>{
-                        message: `The expression '${node.value?.$cstNode?.text}' of type '${actual.identifier}' is not assignable to '${node.name}' with type '${expected.identifier}'`,
+                        message: `The expression '${node.value?.$cstNode?.text}' of type '${actual.name}' is not assignable to '${node.name}' with type '${expected.name}'`,
                         domainProperty: 'value' }),
                 ];
             }
             if (isBinaryExpression(node) && node.operator === '=') {
                 return typir.validation.constraints.ensureNodeIsAssignable(node.right, node.left, (actual, expected) => <ValidationMessageDetails>{
-                    message: `The expression '${node.right.$cstNode?.text}' of type '${actual.identifier}' is not assignable to '${node.left}' with type '${expected.identifier}'`,
+                    message: `The expression '${node.right.$cstNode?.text}' of type '${actual.name}' is not assignable to '${node.left}' with type '${expected.name}'`,
                     domainProperty: 'value' });
             }
             // TODO Idee: Validierung für Langium-binding an AstTypen hängen wie es standardmäßig in Langium gemacht wird => ist auch performanter => dafür API hier anpassen/umbauen
             if (isBinaryExpression(node) && (node.operator === '==' || node.operator === '!=')) {
                 return typir.validation.constraints.ensureNodeIsEquals(node.left, node.right, (actual, expected) => <ValidationMessageDetails>{
-                    message: `This comparison will always return '${node.operator === '==' ? 'false' : 'true'}' as '${node.left.$cstNode?.text}' and '${node.right.$cstNode?.text}' have the different types '${actual.identifier}' and '${expected.identifier}'.`,
+                    message: `This comparison will always return '${node.operator === '==' ? 'false' : 'true'}' as '${node.left.$cstNode?.text}' and '${node.right.$cstNode?.text}' have the different types '${actual.name}' and '${expected.name}'.`,
                     domainElement: node, // mark the 'operator' property! (note that "node.right" and "node.left" are the input for Typir)
                     domainProperty: 'operator',
                     severity: 'warning' });
@@ -250,7 +250,7 @@ export function createTypir(domainNodeEntry: AstNode): Typir {
                 if (functionDeclaration && functionDeclaration.returnType.primitive && functionDeclaration.returnType.primitive !== 'void' && node.value) {
                     // the return value must fit to the return type of the function
                     return typir.validation.constraints.ensureNodeIsAssignable(node.value, functionDeclaration.returnType, (actual, expected) => <ValidationMessageDetails>{
-                        message: `The expression '${node.value!.$cstNode?.text}' of type '${actual.identifier}' is not usable as return value for the function '${functionDeclaration.name}' with return type '${expected.identifier}'.`,
+                        message: `The expression '${node.value!.$cstNode?.text}' of type '${actual.name}' is not usable as return value for the function '${functionDeclaration.name}' with return type '${expected.name}'.`,
                         domainProperty: 'value' });
                 }
             }

--- a/examples/lox/test/lox-type-checking.test.ts
+++ b/examples/lox/test/lox-type-checking.test.ts
@@ -155,6 +155,31 @@ describe('Explicitly test type checking for LOX', () => {
 
 });
 
+describe('Test internal validation of Typir for cycles in the class inheritance hierarchy', () => {
+    // note that inference problems occur here due to the order of class declarations! after fixing that issue, errors regarding cycles should occur!
+
+    test.fails('3 involved classes', async () => {
+        await validate(`
+            class MyClass1 < MyClass3 { }
+            class MyClass2 < MyClass1 { }
+            class MyClass3 < MyClass2 { }
+        `, 0);
+    });
+
+    test.fails('2 involved classes', async () => {
+        await validate(`
+            class MyClass1 < MyClass2 { }
+            class MyClass2 < MyClass1 { }
+        `, 0);
+    });
+
+    test.fails('1 involved class', async () => {
+        await validate(`
+            class MyClass1 < MyClass1 { }
+        `, 0);
+    });
+});
+
 async function validate(lox: string, errors: number, warnings: number = 0) {
     const document = await parseDocument(loxServices, lox.trim());
     const diagnostics: Diagnostic[] = await loxServices.validation.DocumentValidator.validateDocument(document);

--- a/examples/lox/test/lox-type-checking.test.ts
+++ b/examples/lox/test/lox-type-checking.test.ts
@@ -59,6 +59,25 @@ describe('Explicitly test type checking for LOX', () => {
         await validate('fun myFunction() : number { return true; }', 1);
     });
 
+    test('overloaded function: different return types are not enough', async () => {
+        await validate(`
+            fun myFunction() : boolean { return true; }
+            fun myFunction() : number { return 2; }
+        `, 1);
+    });
+    test('overloaded function: different parameter names are not enough', async () => {
+        await validate(`
+            fun myFunction(input: boolean) : boolean { return true; }
+            fun myFunction(other: boolean) : boolean { return true; }
+        `, 1);
+    });
+    test('overloaded function: but different parameter types are fine', async () => {
+        await validate(`
+            fun myFunction(input: boolean) : boolean { return true; }
+            fun myFunction(input: number) : boolean { return true; }
+        `, 0);
+    });
+
     test('use overloaded operators: +', async () => {
         await validate('var myVar : number = 2 + 3;', 0, 0);
         await validate('var myVar : string = "a" + "b";', 0, 0);

--- a/examples/ox/examples/basic.ox
+++ b/examples/ox/examples/basic.ox
@@ -7,11 +7,6 @@ false; // Not *not* false.
 1234;  // An integer.
 12.34; // A decimal number.
 
-// Strings
-// "I am a string";
-// "";    // The empty string.
-// "123"; // This is a string, not a number.
-
 // variables
 var n: number = 12;
 var b: boolean = true;

--- a/examples/ox/src/language/ox-type-checking.ts
+++ b/examples/ox/src/language/ox-type-checking.ts
@@ -157,13 +157,13 @@ export function createTypir(domainNodeEntry: AstNode): Typir {
                     ...typir.validation.constraints.ensureNodeHasNotType(node, typeVoid,
                         () => <ValidationMessageDetails>{ message: "Variables can't be declared with the type 'void'.", domainProperty: 'type' }),
                     ...typir.validation.constraints.ensureNodeIsAssignable(node.value, node,
-                        (actual, expected) => <ValidationMessageDetails>{ message: `The initialization expression '${node.value?.$cstNode?.text}' of type '${actual.identifier}' is not assignable to the variable '${node.name}' with type '${expected.identifier}'.`, domainProperty: 'value' })
+                        (actual, expected) => <ValidationMessageDetails>{ message: `The initialization expression '${node.value?.$cstNode?.text}' of type '${actual.name}' is not assignable to the variable '${node.name}' with type '${expected.name}'.`, domainProperty: 'value' })
                 ];
             }
             if (isAssignmentStatement(node) && node.varRef.ref) {
                 return typir.validation.constraints.ensureNodeIsAssignable(node.value, node.varRef.ref,
                     (actual, expected) => <ValidationMessageDetails>{
-                        message: `The expression '${node.value.$cstNode?.text}' of type '${actual.identifier}' is not assignable to the variable '${node.varRef.ref!.name}' with type '${expected.identifier}'.`,
+                        message: `The expression '${node.value.$cstNode?.text}' of type '${actual.name}' is not assignable to the variable '${node.varRef.ref!.name}' with type '${expected.name}'.`,
                         domainProperty: 'value',
                     });
             }

--- a/examples/ox/src/language/ox-type-checking.ts
+++ b/examples/ox/src/language/ox-type-checking.ts
@@ -155,13 +155,13 @@ export function createTypir(domainNodeEntry: AstNode): Typir {
                     ...typir.validation.constraints.ensureNodeHasNotType(node, typeVoid,
                         () => <ValidationMessageDetails>{ message: "Variables can't be declared with the type 'void'.", domainProperty: 'type' }),
                     ...typir.validation.constraints.ensureNodeIsAssignable(node.value, node,
-                        (actual, expected) => <ValidationMessageDetails>{ message: `The initialization expression '${node.value?.$cstNode?.text}' of type '${actual.name}' is not assignable to the variable '${node.name}' with type '${expected.name}'.`, domainProperty: 'value' })
+                        (actual, expected) => <ValidationMessageDetails>{ message: `The initialization expression '${node.value?.$cstNode?.text}' of type '${actual.identifier}' is not assignable to the variable '${node.name}' with type '${expected.identifier}'.`, domainProperty: 'value' })
                 ];
             }
             if (isAssignmentStatement(node) && node.varRef.ref) {
                 return typir.validation.constraints.ensureNodeIsAssignable(node.value, node.varRef.ref,
                     (actual, expected) => <ValidationMessageDetails>{
-                        message: `The expression '${node.value.$cstNode?.text}' of type '${actual.name}' is not assignable to the variable '${node.varRef.ref!.name}' with type '${expected.name}'.`,
+                        message: `The expression '${node.value.$cstNode?.text}' of type '${actual.identifier}' is not assignable to the variable '${node.varRef.ref!.name}' with type '${expected.identifier}'.`,
                         domainProperty: 'value',
                     });
             }

--- a/examples/ox/src/language/ox-type-checking.ts
+++ b/examples/ox/src/language/ox-type-checking.ts
@@ -60,8 +60,10 @@ export function createTypir(domainNodeEntry: AstNode): Typir {
     }
     // ==, != for booleans and numbers
     for (const operator of ['==', '!=']) {
-        operators.createBinaryOperator({ name: operator, signature: { left: typeNumber, right: typeNumber, return: typeBool }, inferenceRule: binaryInferenceRule });
-        operators.createBinaryOperator({ name: operator, signature: { left: typeBool, right: typeBool, return: typeBool }, inferenceRule: binaryInferenceRule });
+        operators.createBinaryOperator({ name: operator, signature: [
+            { left: typeNumber, right: typeNumber, return: typeBool },
+            { left: typeBool, right: typeBool, return: typeBool },
+        ], inferenceRule: binaryInferenceRule });
     }
 
     // unary operators

--- a/examples/ox/test/ox-type-checking.test.ts
+++ b/examples/ox/test/ox-type-checking.test.ts
@@ -59,6 +59,9 @@ describe('Explicitly test type checking for OX', () => {
         await validate('var myResult: boolean = 2 != 3;', 0);
         await validate('var myResult: boolean = true == false;', 0);
         await validate('var myResult: boolean = true != false;', 0);
+
+        await validate('var myResult: boolean = true == 3;', 1);
+        await validate('var myResult: boolean = 2 != false;', 1);
     });
 
     test('unary operator: !', async () => {

--- a/packages/typir/src/features/assignability.ts
+++ b/packages/typir/src/features/assignability.ts
@@ -37,16 +37,22 @@ export class DefaultTypeAssignability implements TypeAssignability {
     }
 
     getAssignabilityProblem(source: Type, target: Type): AssignabilityProblem | undefined {
-        // conversion possible?
-        if (this.typir.conversion.isConvertible(source, target, 'IMPLICIT')) {
+        // 1. are both types equal?
+        if (this.typir.equality.areTypesEqual(source, target)) {
             return undefined;
         }
 
-        // allow the types kind to determine about sub-type relationships
+        // 2. implicit conversion from source to target possible?
+        if (this.typir.conversion.isImplicitExplicitConvertible(source, target)) {
+            return undefined;
+        }
+
+        // 3. is the source a sub-type of the target?
         const subTypeResult = this.typir.subtype.getSubTypeProblem(source, target);
         if (subTypeResult === undefined) {
             return undefined;
         } else {
+            // return the found sub-type issues
             return {
                 $problem: AssignabilityProblem,
                 source,

--- a/packages/typir/src/features/assignability.ts
+++ b/packages/typir/src/features/assignability.ts
@@ -4,17 +4,19 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { Type, isType } from '../graph/type-node.js';
+import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem } from '../utils/utils-definitions.js';
+import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
 
-export interface AssignabilityProblem {
+export interface AssignabilityProblem extends TypirProblem {
+    $problem: 'AssignabilityProblem';
     source: Type;
     target: Type;
     subProblems: TypirProblem[];
 }
+export const AssignabilityProblem = 'AssignabilityProblem';
 export function isAssignabilityProblem(problem: unknown): problem is AssignabilityProblem {
-    return typeof problem === 'object' && problem !== null && isType((problem as AssignabilityProblem).source) && isType((problem as AssignabilityProblem).target);
+    return isConcreteTypirProblem(problem, AssignabilityProblem);
 }
 
 export interface TypeAssignability {
@@ -46,6 +48,7 @@ export class DefaultTypeAssignability implements TypeAssignability {
             return undefined;
         } else {
             return {
+                $problem: AssignabilityProblem,
                 source,
                 target,
                 subProblems: [subTypeResult]

--- a/packages/typir/src/features/assignability.ts
+++ b/packages/typir/src/features/assignability.ts
@@ -6,7 +6,7 @@
 
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
+import { isSpecificTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
 
 export interface AssignabilityProblem extends TypirProblem {
     $problem: 'AssignabilityProblem';
@@ -16,7 +16,7 @@ export interface AssignabilityProblem extends TypirProblem {
 }
 export const AssignabilityProblem = 'AssignabilityProblem';
 export function isAssignabilityProblem(problem: unknown): problem is AssignabilityProblem {
-    return isConcreteTypirProblem(problem, AssignabilityProblem);
+    return isSpecificTypirProblem(problem, AssignabilityProblem);
 }
 
 export interface TypeAssignability {

--- a/packages/typir/src/features/caching.ts
+++ b/packages/typir/src/features/caching.ts
@@ -7,16 +7,17 @@
 import { TypeEdge } from '../graph/type-edge.js';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
+import { assertTrue } from '../utils/utils.js';
 
 /**
  * Caches relationships between types.
  */
 export interface TypeRelationshipCaching {
-    getRelationship(from: Type, to: Type, meaning: string, directed: boolean): { relationship: RelationshipKind, additionalData: unknown };
-    setRelationship(from: Type, to: Type, meaning: string, directed: boolean, newRelationship: RelationshipKind | undefined, additionalData: unknown): void;
+    getRelationship<T extends TypeEdge>(from: Type, to: Type, $meaning: T['$meaning'], directed: boolean): T | undefined;
+    setOrUpdateRelationship<T extends TypeEdge>(edgeToCache: T, directed: boolean, newRelationship: CachingKind): void;
 }
 
-export type RelationshipKind = 'PENDING' | 'UNKNOWN' | 'LINK_EXISTS' | 'NO_LINK';
+export type CachingKind = 'PENDING' | 'UNKNOWN' | 'LINK_EXISTS' | 'NO_LINK';
 
 export class DefaultTypeRelationshipCaching implements TypeRelationshipCaching {
     protected readonly typir: Typir;
@@ -25,75 +26,60 @@ export class DefaultTypeRelationshipCaching implements TypeRelationshipCaching {
         this.typir = typir;
     }
 
-    getRelationship(from: Type, to: Type, meaning: string, directed: boolean): { relationship: RelationshipKind, additionalData: unknown } {
-        let edge = this.getEdge(from, to, meaning);
+    getRelationship<T extends TypeEdge>(from: Type, to: Type, $meaning: T['$meaning'], directed: boolean): T | undefined {
+        let edge = this.getEdge(from, to, $meaning);
         if (!edge && directed === false) {
             // in case of non-directed edges, check the opposite direction as well
-            edge = this.getEdge(to, from, meaning);
+            edge = this.getEdge(to, from, $meaning);
         }
-        if (edge) {
-            const result = edge.properties.get(TYPE_CACHING_RELATIONSHIP);
-            if (result && typeof result === 'string') {
-                return {
-                    relationship: result as RelationshipKind,
-                    additionalData: edge.properties.get(TYPE_CACHING_ADDITIONAL),
-                };
-            }
-        }
-        return { relationship: 'UNKNOWN', additionalData: undefined };
+        return edge;
     }
 
-    setRelationship(from: Type, to: Type, meaning: string, _directed: boolean, newRelationship: RelationshipKind | undefined, additionalData: unknown = undefined): void {
-        // don't cache some values (but ensure, that PENDING is overridden/updated!)
-        if (this.storeKind(newRelationship) === false) {
-            newRelationship = undefined; // 'undefined' indicates to remove an existing edge
-        }
+    setOrUpdateRelationship<T extends TypeEdge>(edgeToCache: T, _directed: boolean, newRelationship: CachingKind): void {
+        // identify the edge to store the value
+        let edge = this.getEdge<T>(edgeToCache.from, edgeToCache.to, edgeToCache.$meaning);
 
-        // manage the edge to store the value
-        let edge = this.getEdge(from, to, meaning);
-        if (newRelationship === undefined) {
-            // un-set the relationship
+        // don't cache some values (but ensure, that PENDING is overridden/updated!) =>  un-set the relationship
+        if (this.storeKind(newRelationship) === false) {
             if (edge) {
                 this.typir.graph.removeEdge(edge);
+            } else {
+                // no edge exists, no edge wanted => nothing to do
             }
             return;
         }
+
+        // handle missing edge
         if (!edge) {
-            // create missing edge
-            edge = new TypeEdge(from, to, meaning);
+            edge = edgeToCache; // reuse the given edge
             this.typir.graph.addEdge(edge);
+            return;
         }
 
-        // set/update the values of the edge
-        edge.properties.set(TYPE_CACHING_RELATIONSHIP, newRelationship);
-        if (this.storeAdditionalData(additionalData)) {
-            edge.properties.set(TYPE_CACHING_ADDITIONAL, additionalData);
-        } else {
-            edge.properties.delete(TYPE_CACHING_ADDITIONAL);
+        // set/update the values of the existing edge
+        edge.cachingInformation = newRelationship;
+        assertTrue(edge.$meaning === edgeToCache.$meaning);
+        // update data of specific edges!
+        const propertiesToIgnore: Array<keyof TypeEdge> = ['from', 'to', '$meaning', 'cachingInformation'];
+        for (const v of Object.keys(edgeToCache)) {
+            if (propertiesToIgnore.includes(v as keyof TypeEdge)) {
+                // don't update these properties
+            } else {
+                edge[v as keyof T] = edgeToCache[v as keyof T];
+            }
         }
     }
 
     /** Override this function to store more or less relationships. */
-    protected storeKind(value: RelationshipKind | undefined): boolean {
+    protected storeKind(value: CachingKind | undefined): boolean {
         // return value === 'PENDING' || value === 'LINK_EXISTS';
         return value === 'PENDING';
     }
 
-    /** Override this function to store more (or less) data like 'undefined'. */
-    protected storeAdditionalData(additionalData: unknown): boolean {
-        if (additionalData) {
-            return true;
-        }
-        return false;
-    }
-
-    protected getEdge(from: Type, to: Type, meaning: string): TypeEdge | undefined {
-        return from.getOutgoingEdges(meaning).find(edge => edge.to === to);
+    protected getEdge<T extends TypeEdge>(from: Type, to: Type, $meaning: T['$meaning']): T | undefined {
+        return from.getOutgoingEdges<T>($meaning).find(edge => edge.to === to);
     }
 }
-
-const TYPE_CACHING_RELATIONSHIP = 'TypeRelationshipCaching_Kind';
-const TYPE_CACHING_ADDITIONAL = 'TypeRelationshipCaching_Additional';
 
 
 /**

--- a/packages/typir/src/features/caching.ts
+++ b/packages/typir/src/features/caching.ts
@@ -13,11 +13,22 @@ import { assertTrue } from '../utils/utils.js';
  * Caches relationships between types.
  */
 export interface TypeRelationshipCaching {
-    getRelationship<T extends TypeEdge>(from: Type, to: Type, $meaning: T['$meaning'], directed: boolean): T | undefined;
-    setOrUpdateRelationship<T extends TypeEdge>(edgeToCache: T, directed: boolean, newRelationship: CachingKind): void;
+    getRelationshipUnidirectional<T extends TypeEdge>(from: Type, to: Type, $relation: T['$relation']): T | undefined;
+    getRelationshipBidirectional<T extends TypeEdge>(from: Type, to: Type, $relation: T['$relation']): T | undefined;
+
+    setOrUpdateUnidirectionalRelationship<T extends TypeEdge>(edgeToCache: T, edgeCaching: EdgeCachingInformation): T | undefined;
+    setOrUpdateBidirectionalRelationship<T extends TypeEdge>(edgeToCache: T, edgeCaching: EdgeCachingInformation): T | undefined;
 }
 
-export type CachingKind = 'PENDING' | 'UNKNOWN' | 'LINK_EXISTS' | 'NO_LINK';
+export type EdgeCachingInformation =
+    /** The analysis, whether the current relationship holds, is still ongoing. */
+    'PENDING' |
+    /** It is unknown, whether the current relationship holds */
+    'UNKNOWN' |
+    /** The current relationship exists. */
+    'LINK_EXISTS' |
+    /** The current relationship does not exist. */
+    'NO_LINK';
 
 export class DefaultTypeRelationshipCaching implements TypeRelationshipCaching {
     protected readonly typir: Typir;
@@ -26,58 +37,65 @@ export class DefaultTypeRelationshipCaching implements TypeRelationshipCaching {
         this.typir = typir;
     }
 
-    getRelationship<T extends TypeEdge>(from: Type, to: Type, $meaning: T['$meaning'], directed: boolean): T | undefined {
-        let edge = this.getEdge(from, to, $meaning);
-        if (!edge && directed === false) {
-            // in case of non-directed edges, check the opposite direction as well
-            edge = this.getEdge(to, from, $meaning);
-        }
-        return edge;
+    getRelationshipUnidirectional<T extends TypeEdge>(from: Type, to: Type, $relation: T['$relation']): T | undefined {
+        return from.getOutgoingEdges<T>($relation).find(edge => edge.to === to);
+    }
+    getRelationshipBidirectional<T extends TypeEdge>(from: Type, to: Type, $relation: T['$relation']): T | undefined {
+        // for bidirectional edges, check outgoing and incoming edges, since the graph contains only a single edge!
+        return from.getEdges<T>($relation).find(edge => edge.to === to);
     }
 
-    setOrUpdateRelationship<T extends TypeEdge>(edgeToCache: T, _directed: boolean, newRelationship: CachingKind): void {
+    setOrUpdateUnidirectionalRelationship<T extends TypeEdge>(edgeToCache: T, edgeCaching: EdgeCachingInformation): T | undefined {
+        return this.setOrUpdateRelationship(edgeToCache, edgeCaching, false);
+    }
+    setOrUpdateBidirectionalRelationship<T extends TypeEdge>(edgeToCache: T, edgeCaching: EdgeCachingInformation): T | undefined {
+        return this.setOrUpdateRelationship(edgeToCache, edgeCaching, true);
+    }
+
+    protected setOrUpdateRelationship<T extends TypeEdge>(edgeToCache: T, edgeCaching: EdgeCachingInformation, bidirectional: boolean): T | undefined {
         // identify the edge to store the value
-        let edge = this.getEdge<T>(edgeToCache.from, edgeToCache.to, edgeToCache.$meaning);
+        const edge: T | undefined = bidirectional
+            ? this.getRelationshipBidirectional(edgeToCache.from, edgeToCache.to, edgeToCache.$relation)
+            : this.getRelationshipUnidirectional(edgeToCache.from, edgeToCache.to, edgeToCache.$relation);
 
         // don't cache some values (but ensure, that PENDING is overridden/updated!) =>  un-set the relationship
-        if (this.storeKind(newRelationship) === false) {
+        if (this.storeCachingInformation(edgeCaching) === false) {
             if (edge) {
                 this.typir.graph.removeEdge(edge);
             } else {
                 // no edge exists, no edge wanted => nothing to do
             }
-            return;
+            return undefined;
         }
 
         // handle missing edge
         if (!edge) {
-            edge = edgeToCache; // reuse the given edge
-            this.typir.graph.addEdge(edge);
-            return;
+            // reuse the given edge
+            this.typir.graph.addEdge(edgeToCache);
+            // in case of non-directed edges, check the opposite direction as well
+            return edgeToCache;
         }
 
         // set/update the values of the existing edge
-        edge.cachingInformation = newRelationship;
-        assertTrue(edge.$meaning === edgeToCache.$meaning);
+        edge.cachingInformation = edgeCaching;
+        assertTrue(edge.$relation === edgeToCache.$relation);
         // update data of specific edges!
-        const propertiesToIgnore: Array<keyof TypeEdge> = ['from', 'to', '$meaning', 'cachingInformation'];
-        for (const v of Object.keys(edgeToCache)) {
+        // Object.assign throws an error for readonly properties => it cannot be used here!
+        const propertiesToIgnore: Array<keyof TypeEdge> = ['from', 'to', '$relation', 'cachingInformation'];
+        const keys = Object.keys(edgeToCache) as Array<keyof T>;
+        for (const v of keys) {
             if (propertiesToIgnore.includes(v as keyof TypeEdge)) {
                 // don't update these properties
             } else {
-                edge[v as keyof T] = edgeToCache[v as keyof T];
+                edge[v] = edgeToCache[v];
             }
         }
+        return edge as T;
     }
 
-    /** Override this function to store more or less relationships. */
-    protected storeKind(value: CachingKind | undefined): boolean {
-        // return value === 'PENDING' || value === 'LINK_EXISTS';
-        return value === 'PENDING';
-    }
-
-    protected getEdge<T extends TypeEdge>(from: Type, to: Type, $meaning: T['$meaning']): T | undefined {
-        return from.getOutgoingEdges<T>($meaning).find(edge => edge.to === to);
+    /** Override this function to store more or less relationships in the type graph. */
+    protected storeCachingInformation(value: EdgeCachingInformation | undefined): boolean {
+        return value === 'PENDING' || value === 'LINK_EXISTS';
     }
 }
 
@@ -85,7 +103,6 @@ export class DefaultTypeRelationshipCaching implements TypeRelationshipCaching {
 /**
  * Domain element-to-Type caching for type inference.
  */
-
 export interface DomainElementInferenceCaching {
     cacheSet(domainElement: unknown, type: Type): void;
     cacheGet(domainElement: unknown): Type | undefined;

--- a/packages/typir/src/features/conversion.ts
+++ b/packages/typir/src/features/conversion.ts
@@ -120,9 +120,10 @@ export class DefaultTypeConversion implements TypeConversion {
         if (!edge) {
             // create a missing edge (with the desired mode)
             edge = {
-                $meaning: ConversionEdge,
+                $relation: ConversionEdge,
                 from,
                 to,
+                cachingInformation: 'LINK_EXISTS',
                 mode,
             };
             this.typir.graph.addEdge(edge);
@@ -204,11 +205,11 @@ export class DefaultTypeConversion implements TypeConversion {
 }
 
 export interface ConversionEdge extends TypeEdge {
-    readonly $meaning: 'ConversionEdge';
+    readonly $relation: 'ConversionEdge';
     mode: ConversionMode;
 }
 export const ConversionEdge = 'ConversionEdge';
 
 export function isConversionEdge(edge: unknown): edge is ConversionEdge {
-    return isTypeEdge(edge) && edge.$meaning === ConversionEdge;
+    return isTypeEdge(edge) && edge.$relation === ConversionEdge;
 }

--- a/packages/typir/src/features/equality.ts
+++ b/packages/typir/src/features/equality.ts
@@ -8,7 +8,7 @@ import { assertUnreachable } from 'langium';
 import { isTypeEdge, TypeEdge } from '../graph/type-edge.js';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
+import { isSpecificTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
 import { EdgeCachingInformation, TypeRelationshipCaching } from './caching.js';
 
 export interface TypeEqualityProblem extends TypirProblem {
@@ -19,7 +19,7 @@ export interface TypeEqualityProblem extends TypirProblem {
 }
 export const TypeEqualityProblem = 'TypeEqualityProblem';
 export function isTypeEqualityProblem(problem: unknown): problem is TypeEqualityProblem {
-    return isConcreteTypirProblem(problem, TypeEqualityProblem);
+    return isSpecificTypirProblem(problem, TypeEqualityProblem);
 }
 
 // TODO comments

--- a/packages/typir/src/features/equality.ts
+++ b/packages/typir/src/features/equality.ts
@@ -5,18 +5,20 @@
  ******************************************************************************/
 
 import { assertUnreachable } from 'langium';
-import { Type, isType } from '../graph/type-node.js';
+import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem } from '../utils/utils-definitions.js';
+import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
 import { RelationshipKind, TypeRelationshipCaching } from './caching.js';
 
-export interface TypeEqualityProblem {
+export interface TypeEqualityProblem extends TypirProblem {
+    $problem: 'TypeEqualityProblem';
     type1: Type;
     type2: Type;
     subProblems: TypirProblem[]; // might be empty
 }
+export const TypeEqualityProblem = 'TypeEqualityProblem';
 export function isTypeEqualityProblem(problem: unknown): problem is TypeEqualityProblem {
-    return typeof problem === 'object' && problem !== null && isType((problem as TypeEqualityProblem).type1) && isType((problem as TypeEqualityProblem).type2);
+    return isConcreteTypirProblem(problem, TypeEqualityProblem);
 }
 
 // TODO comments
@@ -59,6 +61,7 @@ export class DefaultTypeEquality implements TypeEquality {
         }
         if (linkRelationship === 'NO_LINK') {
             return {
+                $problem: TypeEqualityProblem,
                 type1,
                 type2,
                 subProblems: isTypeEqualityProblem(linkData.additionalData) ? [linkData.additionalData] : [],
@@ -102,6 +105,7 @@ export class DefaultTypeEquality implements TypeEquality {
             // if type1 and type2 have the same kind, there is no need to check the same kind twice
             // TODO does this make sense?
             return {
+                $problem: TypeEqualityProblem,
                 type1,
                 type2,
                 subProblems: result1,
@@ -114,6 +118,7 @@ export class DefaultTypeEquality implements TypeEquality {
         }
         // both types reported, that they are diffferent
         return {
+            $problem: TypeEqualityProblem,
             type1,
             type2,
             subProblems: [...result1, ...result2] // return the equality problems of both types

--- a/packages/typir/src/features/inference.ts
+++ b/packages/typir/src/features/inference.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { assertUnreachable } from 'langium';
 import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
@@ -192,7 +193,7 @@ export class DefaultTypeInferenceCollector implements TypeInferenceCollector {
                 } else {
                     // no result for this inference rule => check the next inference rules
                 }
-            } else {
+            } else if (typeof rule === 'object') {
                 // more complex case with inferring the type for children
                 const ruleResult: TypeInferenceResultWithInferringChildren = rule.inferTypeWithoutChildren(domainElement, this.typir);
                 if (Array.isArray(ruleResult)) {
@@ -242,6 +243,8 @@ export class DefaultTypeInferenceCollector implements TypeInferenceCollector {
                         // no result for this inference rule => check the next inference rules
                     }
                 }
+            } else {
+                assertUnreachable(rule);
             }
         }
 

--- a/packages/typir/src/features/inference.ts
+++ b/packages/typir/src/features/inference.ts
@@ -7,7 +7,7 @@
 import { assertUnreachable } from 'langium';
 import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
+import { isSpecificTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
 
 export interface InferenceProblem extends TypirProblem {
     $problem: 'InferenceProblem';
@@ -19,7 +19,7 @@ export interface InferenceProblem extends TypirProblem {
 }
 export const InferenceProblem = 'InferenceProblem';
 export function isInferenceProblem(problem: unknown): problem is InferenceProblem {
-    return isConcreteTypirProblem(problem, InferenceProblem);
+    return isSpecificTypirProblem(problem, InferenceProblem);
 }
 
 // Type and Value to indicate, that an inference rule is intended for another case, and therefore is unable to infer a type for the current case.

--- a/packages/typir/src/features/printing.ts
+++ b/packages/typir/src/features/printing.ts
@@ -46,11 +46,11 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
         const left = problem.firstValue;
         const right = problem.secondValue;
         if (left !== undefined && right !== undefined) {
-            result = result + `${left} and ${right} do not match.`;
+            result += `${left} and ${right} do not match.`;
         } else if (left !== undefined && right === undefined) {
-            result = result + `${left} on the left has no opposite value on the right to match.`;
+            result += `${left} on the left has no opposite value on the right to match.`;
         } else if (left === undefined && right !== undefined) {
-            result = result + `there is no value on the left to match with ${right} on the right.`;
+            result += `there is no value on the left to match with ${right} on the right.`;
         } else {
             throw new Error();
         }
@@ -64,23 +64,23 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
         let result = '';
         if (problem.propertyName) {
             if (problem.propertyIndex) {
-                result = result + `For property '${problem.propertyName} at index ${problem.propertyIndex}', `;
+                result += `For property '${problem.propertyName} at index ${problem.propertyIndex}', `;
             } else {
-                result = result + `For property '${problem.propertyName}', `;
+                result += `For property '${problem.propertyName}', `;
             }
         } else if (problem.propertyIndex) {
-            result = result + `At index ${problem.propertyIndex}, `;
+            result += `At index ${problem.propertyIndex}, `;
         } else {
-            result = result + 'At an unknown location, ';
+            result += 'At an unknown location, ';
         }
         if (left !== undefined && right !== undefined) {
-            result = result + `the types '${this.printTypeName(left)}' and '${this.printTypeName(right)}' do not match.`;
+            result += `the types '${this.printTypeName(left)}' and '${this.printTypeName(right)}' do not match.`;
         } else if (left !== undefined && right === undefined) {
-            result = result + `the type '${this.printTypeName(left)}' on the left has no opposite type on the right to match with.`;
+            result += `the type '${this.printTypeName(left)}' on the left has no opposite type on the right to match with.`;
         } else if (left === undefined && right !== undefined) {
-            result = result + `there is no type on the left to match with the type '${this.printTypeName(right)}' on the right.`;
+            result += `there is no type on the left to match with the type '${this.printTypeName(right)}' on the right.`;
         } else {
-            result = result + 'both types are unclear.';
+            result += 'both types are unclear.';
         }
         result = this.printIndentation(result, level);
         result = this.printSubProblems(result, problem.subProblems, level);
@@ -111,10 +111,10 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
     printInferenceProblem(problem: InferenceProblem, level: number = 0): string {
         let result = `While inferring the type for ${this.printDomainElement(problem.domainElement)}, at ${problem.location}`;
         if (problem.inferenceCandidate) {
-            result = result + ` of the type '${this.printTypeName(problem.inferenceCandidate)}' as candidate to infer`;
+            result += ` of the type '${this.printTypeName(problem.inferenceCandidate)}' as candidate to infer`;
         }
-        result = result + ', some problems occurred.';
-        // Since Rules have no name (yet), it is not possible to print problem.rule here.
+        result += ', some problems occurred.';
+        // Since Rules have no name, it is not possible to print problem.rule here.
         result = this.printIndentation(result, level);
         result = this.printSubProblems(result, problem.subProblems, level);
         return result;

--- a/packages/typir/src/features/printing.ts
+++ b/packages/typir/src/features/printing.ts
@@ -28,9 +28,19 @@ export interface ProblemPrinter {
     printTypirProblems(problems: TypirProblem[]): string;
 
     printDomainElement(domainElement: unknown, sentenceBegin: boolean): string;
-    /** This function should be used by other services, not type.getName(). */
+    /**
+     * This function should be used by other services, instead of using type.getName().
+     * This enables to customize the printing of type names by overriding only this implementation.
+     * @param type the type to print
+     * @returns the name of the given type
+     */
     printTypeName(type: Type): string;
-    /** This function should be used by other services, not type.getUserRepresentation(). */
+    /**
+     * This function should be used by other services, instead of using type.getUserRepresentation().
+     * This enables to customize the printing of type names by overriding only this implementation.
+     * @param type the type to print
+     * @returns the user representation of the given type
+     */
     printTypeUserRepresentation(type: Type): string;
 }
 

--- a/packages/typir/src/features/printing.ts
+++ b/packages/typir/src/features/printing.ts
@@ -28,7 +28,10 @@ export interface ProblemPrinter {
     printTypirProblems(problems: TypirProblem[]): string;
 
     printDomainElement(domainElement: unknown, sentenceBegin: boolean): string;
-    printType(type: Type): string;
+    /** This function should be used by other services, not type.getName(). */
+    printTypeName(type: Type): string;
+    /** This function should be used by other services, not type.getUserRepresentation(). */
+    printTypeUserRepresentation(type: Type): string;
 }
 
 export class DefaultTypeConflictPrinter implements ProblemPrinter {
@@ -65,11 +68,11 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
             result = result + `For property '${problem.index}', `;
         }
         if (left !== undefined && right !== undefined) {
-            result = result + `the types '${this.printType(left)}' and '${this.printType(right)}' do not match.`;
+            result = result + `the types '${this.printTypeName(left)}' and '${this.printTypeName(right)}' do not match.`;
         } else if (left !== undefined && right === undefined) {
-            result = result + `the type '${this.printType(left)}' on the left has no opposite type on the right to match with.`;
+            result = result + `the type '${this.printTypeName(left)}' on the left has no opposite type on the right to match with.`;
         } else if (left === undefined && right !== undefined) {
-            result = result + `there is no type on the left to match with the type '${this.printType(right)}' on the right.`;
+            result = result + `there is no type on the left to match with the type '${this.printTypeName(right)}' on the right.`;
         } else {
             throw new Error();
         }
@@ -79,21 +82,21 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
     }
 
     printAssignabilityProblem(problem: AssignabilityProblem, level: number = 0): string {
-        let result = `The type '${this.printType(problem.source)}' is not assignable to the type '${this.printType(problem.target)}'.`;
+        let result = `The type '${this.printTypeName(problem.source)}' is not assignable to the type '${this.printTypeName(problem.target)}'.`;
         result = this.printIndentation(result, level);
         result = this.printSubProblems(result, problem.subProblems, level);
         return result;
     }
 
     printSubTypeProblem(problem: SubTypeProblem, level: number = 0): string {
-        let result = `The type '${this.printType(problem.superType)}' is no super-type of '${this.printType(problem.subType)}'.`;
+        let result = `The type '${this.printTypeName(problem.superType)}' is no super-type of '${this.printTypeName(problem.subType)}'.`;
         result = this.printIndentation(result, level);
         result = this.printSubProblems(result, problem.subProblems, level);
         return result;
     }
 
     printTypeEqualityProblem(problem: TypeEqualityProblem, level: number = 0): string {
-        let result = `The types '${this.printType(problem.type1)}' and '${this.printType(problem.type2)}' are not equal.`;
+        let result = `The types '${this.printTypeName(problem.type1)}' and '${this.printTypeName(problem.type2)}' are not equal.`;
         result = this.printIndentation(result, level);
         result = this.printSubProblems(result, problem.subProblems, level);
         return result;
@@ -102,7 +105,7 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
     printInferenceProblem(problem: InferenceProblem, level: number = 0): string {
         let result = `While inferring the type for ${this.printDomainElement(problem.domainElement)}, at ${problem.location}`;
         if (problem.inferenceCandidate) {
-            result = result + ` of the type '${this.printType(problem.inferenceCandidate)}' as candidate to infer`;
+            result = result + ` of the type '${this.printTypeName(problem.inferenceCandidate)}' as candidate to infer`;
         }
         result = result + ', some problems occurred.';
         // Since Rules have no name (yet), it is not possible to print problem.rule here.
@@ -146,7 +149,11 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
         return `${sentenceBegin ? 'T' : 't'}he domain element '${domainElement}'`;
     }
 
-    printType(type: Type): string {
+    printTypeName(type: Type): string {
+        return type.getName();
+    }
+
+    printTypeUserRepresentation(type: Type): string {
         return type.getUserRepresentation();
     }
 

--- a/packages/typir/src/features/printing.ts
+++ b/packages/typir/src/features/printing.ts
@@ -62,10 +62,16 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
         const left = problem.expected;
         const right = problem.actual;
         let result = '';
-        if (typeof problem.index === 'number') {
-            result = result + `At index ${problem.index}, `;
+        if (problem.propertyName) {
+            if (problem.propertyIndex) {
+                result = result + `For property '${problem.propertyName} at index ${problem.propertyIndex}', `;
+            } else {
+                result = result + `For property '${problem.propertyName}', `;
+            }
+        } else if (problem.propertyIndex) {
+            result = result + `At index ${problem.propertyIndex}, `;
         } else {
-            result = result + `For property '${problem.index}', `;
+            result = result + 'At an unknown location, ';
         }
         if (left !== undefined && right !== undefined) {
             result = result + `the types '${this.printTypeName(left)}' and '${this.printTypeName(right)}' do not match.`;
@@ -74,7 +80,7 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
         } else if (left === undefined && right !== undefined) {
             result = result + `there is no type on the left to match with the type '${this.printTypeName(right)}' on the right.`;
         } else {
-            throw new Error();
+            result = result + 'both types are unclear.';
         }
         result = this.printIndentation(result, level);
         result = this.printSubProblems(result, problem.subProblems, level);
@@ -115,7 +121,7 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
     }
 
     printValidationProblem(problem: ValidationProblem, level: number = 0): string {
-        let result = `While validating ${this.printDomainElement(problem.domainElement)}, this ${problem.severity} is found: ${problem.message}`;
+        let result = `While validating ${this.printDomainElement(problem.domainElement)}, this ${problem.severity} is found: ${problem.message}`.trim();
         result = this.printIndentation(result, level);
         result = this.printSubProblems(result, problem.subProblems, level);
         return result;

--- a/packages/typir/src/features/printing.ts
+++ b/packages/typir/src/features/printing.ts
@@ -4,9 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { assertUnreachable } from 'langium';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
 import { IndexedTypeConflict, ValueConflict, isIndexedTypeConflict, isValueConflict } from '../utils/utils-type-comparison.js';
 import { toArray } from '../utils/utils.js';
 import { AssignabilityProblem, isAssignabilityProblem } from './assignability.js';
@@ -14,7 +14,6 @@ import { TypeEqualityProblem, isTypeEqualityProblem } from './equality.js';
 import { InferenceProblem, isInferenceProblem } from './inference.js';
 import { SubTypeProblem, isSubTypeProblem } from './subtype.js';
 import { ValidationProblem, isValidationProblem } from './validation.js';
-import { TypirProblem } from '../utils/utils-definitions.js';
 
 export interface ProblemPrinter {
     printValueConflict(problem: ValueConflict): string;
@@ -135,7 +134,7 @@ export class DefaultTypeConflictPrinter implements ProblemPrinter {
         } else if (isValidationProblem(problem)) {
             return this.printValidationProblem(problem, level);
         } else {
-            assertUnreachable(problem);
+            throw new Error(`Unhandled typir problem ${problem.$problem}`);
         }
     }
 

--- a/packages/typir/src/features/subtype.ts
+++ b/packages/typir/src/features/subtype.ts
@@ -104,14 +104,19 @@ export class DefaultSubType implements SubType {
     }
 
     protected calculateSubType(superType: Type, subType: Type): SubTypeProblem | undefined {
-        // check the types: delegated to the kinds
+        /** Approach:
+         * - delegated to the types, since they realize type-specific sub-type checking
+         * - Therefore, it is not necessary to add special cases for TopType and BottomType here (e.g. if (isTopType(superType)) { return undefined; }).
+         * - Additionally, this allows users of Typir to implement top/bottom types on their own without changing this implementation here!
+         */
+
         // 1st delegate to the kind of the sub type
         const resultSub = subType.analyzeIsSubTypeOf(superType);
         if (resultSub.length <= 0) {
             return undefined;
         }
+        // if sub type and super type have the same kind, there is no need to check the same kind twice
         if (superType.kind.$name === subType.kind.$name) {
-            // if sub type and super type have the same kind, there is no need to check the same kind twice
             // TODO does this make sense?
             return {
                 $problem: SubTypeProblem,
@@ -120,6 +125,7 @@ export class DefaultSubType implements SubType {
                 subProblems: resultSub,
             };
         }
+
         // 2nd delegate to the kind of the super type
         const resultSuper = superType.analyzeIsSuperTypeOf(subType);
         if (resultSuper.length <= 0) {

--- a/packages/typir/src/features/subtype.ts
+++ b/packages/typir/src/features/subtype.ts
@@ -29,7 +29,7 @@ export function isSubTypeProblem(problem: unknown): problem is SubTypeProblem {
  * Analyzes, whether there is a sub type-relationship between two types.
  *
  * The sub-type relationship might be direct or indirect (transitive).
- * If both types are the same, no problems will be reported, since a type is considered as sub-type of itself.
+ * If both types are the same, no problems will be reported, since a type is considered as sub-type of itself (by definition).
  *
  * In theory, the difference between sub type-relationships and super type-relationships are only switched types.
  * But in practise, the default implementation will ask both involved types (if they have different kinds),

--- a/packages/typir/src/features/subtype.ts
+++ b/packages/typir/src/features/subtype.ts
@@ -8,7 +8,7 @@ import { assertUnreachable } from 'langium';
 import { isTypeEdge, TypeEdge } from '../graph/type-edge.js';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
+import { isSpecificTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
 import { EdgeCachingInformation, TypeRelationshipCaching } from './caching.js';
 
 export interface SubTypeProblem extends TypirProblem {
@@ -20,7 +20,7 @@ export interface SubTypeProblem extends TypirProblem {
 }
 export const SubTypeProblem = 'SubTypeProblem';
 export function isSubTypeProblem(problem: unknown): problem is SubTypeProblem {
-    return isConcreteTypirProblem(problem, SubTypeProblem);
+    return isSpecificTypirProblem(problem, SubTypeProblem);
 }
 
 // TODO new feature: allow to mark arbitrary types with a sub-type edge! (similar to conversion!)

--- a/packages/typir/src/features/subtype.ts
+++ b/packages/typir/src/features/subtype.ts
@@ -5,19 +5,21 @@
  ******************************************************************************/
 
 import { assertUnreachable } from 'langium';
-import { Type, isType } from '../graph/type-node.js';
+import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
+import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
 import { RelationshipKind, TypeRelationshipCaching } from './caching.js';
-import { TypirProblem } from '../utils/utils-definitions.js';
 
-export interface SubTypeProblem {
+export interface SubTypeProblem extends TypirProblem {
+    $problem: 'SubTypeProblem';
     // 'undefined' means type or information is missing, 'string' is for data which are no Types
     superType: Type;
     subType: Type;
     subProblems: TypirProblem[]; // might be empty
 }
+export const SubTypeProblem = 'SubTypeProblem';
 export function isSubTypeProblem(problem: unknown): problem is SubTypeProblem {
-    return typeof problem === 'object' && problem !== null && isType((problem as SubTypeProblem).superType) && isType((problem as SubTypeProblem).subType);
+    return isConcreteTypirProblem(problem, SubTypeProblem);
 }
 
 // TODO new feature: allow to mark arbitrary types with a sub-type edge! (similar to conversion!)
@@ -75,6 +77,7 @@ export class DefaultSubType implements SubType {
         }
         if (linkRelationship === 'NO_LINK') {
             return {
+                $problem: SubTypeProblem,
                 superType,
                 subType,
                 subProblems: isSubTypeProblem(linkData.additionalData) ? [linkData.additionalData] : [],
@@ -111,6 +114,7 @@ export class DefaultSubType implements SubType {
             // if sub type and super type have the same kind, there is no need to check the same kind twice
             // TODO does this make sense?
             return {
+                $problem: SubTypeProblem,
                 superType,
                 subType,
                 subProblems: resultSub,
@@ -122,6 +126,7 @@ export class DefaultSubType implements SubType {
             return undefined;
         }
         return {
+            $problem: SubTypeProblem,
             superType,
             subType,
             subProblems: [...resultSuper, ...resultSub], // return the sub-type problems of both types

--- a/packages/typir/src/features/subtype.ts
+++ b/packages/typir/src/features/subtype.ts
@@ -9,7 +9,7 @@ import { isTypeEdge, TypeEdge } from '../graph/type-edge.js';
 import { Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
-import { CachingKind, TypeRelationshipCaching } from './caching.js';
+import { EdgeCachingInformation, TypeRelationshipCaching } from './caching.js';
 
 export interface SubTypeProblem extends TypirProblem {
     $problem: 'SubTypeProblem';
@@ -40,6 +40,10 @@ export function isSubTypeProblem(problem: unknown): problem is SubTypeProblem {
  */
 export interface SubType {
     isSubType(subType: Type, superType: Type): boolean;
+    /* TODO:
+    - no problem ==> sub-type relationship exists
+    - terminology: "no sub-type" is not a problem in general ("it is a qualified NO"), it is just a property! This is a general issue of the current design!
+    */
     getSubTypeProblem(subType: Type, superType: Type): SubTypeProblem | undefined;
 }
 
@@ -56,21 +60,22 @@ export class DefaultSubType implements SubType {
 
     getSubTypeProblem(subType: Type, superType: Type): SubTypeProblem | undefined {
         const cache: TypeRelationshipCaching = this.typir.caching.typeRelationships;
-        const linkData = cache.getRelationship<SubTypeEdge>(subType, superType, SubTypeEdge, true);
-        const linkRelationship = linkData?.cachingInformation ?? 'UNKNOWN';
+        const linkData = cache.getRelationshipUnidirectional<SubTypeEdge>(subType, superType, SubTypeEdge);
+        const subTypeCaching = linkData?.cachingInformation ?? 'UNKNOWN';
 
-        const save = (relationship: CachingKind, error: SubTypeProblem | undefined): void => {
+        function save(subTypeCaching: EdgeCachingInformation, error: SubTypeProblem | undefined): void {
             const newEdge: SubTypeEdge = {
-                $meaning: SubTypeEdge,
+                $relation: SubTypeEdge,
                 from: subType,
                 to: superType,
+                cachingInformation: 'LINK_EXISTS',
                 error,
             };
-            cache.setOrUpdateRelationship(newEdge, true, relationship);
-        };
+            cache.setOrUpdateUnidirectionalRelationship(newEdge, subTypeCaching);
+        }
 
         // skip recursive checking
-        if (linkRelationship === 'PENDING') {
+        if (subTypeCaching === 'PENDING') {
             /** 'undefined' should be correct here ...
              * - since this relationship will be checked earlier/higher/upper in the call stack again
              * - since this values is not cached and therefore NOT reused in the earlier call! */
@@ -78,10 +83,10 @@ export class DefaultSubType implements SubType {
         }
 
         // the result is already known
-        if (linkRelationship === 'LINK_EXISTS') {
+        if (subTypeCaching === 'LINK_EXISTS') {
             return undefined;
         }
-        if (linkRelationship === 'NO_LINK') {
+        if (subTypeCaching === 'NO_LINK') {
             return {
                 $problem: SubTypeProblem,
                 superType,
@@ -91,12 +96,12 @@ export class DefaultSubType implements SubType {
         }
 
         // do the expensive calculation now
-        if (linkRelationship === 'UNKNOWN') {
+        if (subTypeCaching === 'UNKNOWN') {
             // mark the current relationship as PENDING to detect and resolve cycling checks
             save('PENDING', undefined);
 
-            // do the real calculation
-            const result = this.calculateSubType(superType, subType);
+            // do the actual calculation
+            const result = this.calculateSubType(subType, superType);
 
             // this allows to cache results (and to re-set the PENDING state)
             if (result === undefined) {
@@ -106,12 +111,12 @@ export class DefaultSubType implements SubType {
             }
             return result;
         }
-        assertUnreachable(linkRelationship);
+        assertUnreachable(subTypeCaching);
     }
 
-    protected calculateSubType(superType: Type, subType: Type): SubTypeProblem | undefined {
+    protected calculateSubType(subType: Type, superType: Type): SubTypeProblem | undefined {
         /** Approach:
-         * - delegated to the types, since they realize type-specific sub-type checking
+         * - delegate the calculation to the types, since they realize type-specific sub-type checking
          * - Therefore, it is not necessary to add special cases for TopType and BottomType here (e.g. if (isTopType(superType)) { return undefined; }).
          * - Additionally, this allows users of Typir to implement top/bottom types on their own without changing this implementation here!
          */
@@ -120,16 +125,6 @@ export class DefaultSubType implements SubType {
         const resultSub = subType.analyzeIsSubTypeOf(superType);
         if (resultSub.length <= 0) {
             return undefined;
-        }
-        // if sub type and super type have the same kind, there is no need to check the same kind twice
-        if (superType.kind.$name === subType.kind.$name) {
-            // TODO does this make sense?
-            return {
-                $problem: SubTypeProblem,
-                superType,
-                subType,
-                subProblems: resultSub,
-            };
         }
 
         // 2nd delegate to the kind of the super type
@@ -147,11 +142,11 @@ export class DefaultSubType implements SubType {
 }
 
 export interface SubTypeEdge extends TypeEdge {
-    readonly $meaning: 'SubTypeEdge';
+    readonly $relation: 'SubTypeEdge';
     readonly error: SubTypeProblem | undefined;
 }
 export const SubTypeEdge = 'SubTypeEdge';
 
 export function isSubTypeEdge(edge: unknown): edge is SubTypeEdge {
-    return isTypeEdge(edge) && edge.$meaning === SubTypeEdge;
+    return isTypeEdge(edge) && edge.$relation === SubTypeEdge;
 }

--- a/packages/typir/src/features/validation.ts
+++ b/packages/typir/src/features/validation.ts
@@ -6,7 +6,7 @@
 
 import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
+import { isSpecificTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
 import { TypeCheckStrategy, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
 
 export type Severity = 'error' | 'warning' | 'info' | 'hint';
@@ -25,7 +25,7 @@ export interface ValidationProblem extends ValidationMessageDetails, TypirProble
 }
 export const ValidationProblem = 'ValidationProblem';
 export function isValidationProblem(problem: unknown): problem is ValidationProblem {
-    return isConcreteTypirProblem(problem, ValidationProblem);
+    return isSpecificTypirProblem(problem, ValidationProblem);
 }
 
 export type ValidationRule = (domainElement: unknown, typir: Typir) => ValidationProblem[];

--- a/packages/typir/src/features/validation.ts
+++ b/packages/typir/src/features/validation.ts
@@ -121,8 +121,8 @@ export class DefaultValidationConstraints implements ValidationConstraints {
     protected annotateType(type: Type): AnnotatedTypeAfterValidation {
         return {
             type,
-            userRepresentation: this.typir.printer.printType(type),
-            name: type.identifier,
+            userRepresentation: this.typir.printer.printTypeUserRepresentation(type),
+            name: this.typir.printer.printTypeName(type),
         };
     }
 }

--- a/packages/typir/src/features/validation.ts
+++ b/packages/typir/src/features/validation.ts
@@ -70,7 +70,8 @@ export class DefaultValidationConstraints implements ValidationConstraints {
             const actualType = isType(domainNode) ? domainNode : this.typir.inference.inferType(domainNode);
             const expectedType = isType(expected) ? expected : this.typir.inference.inferType(expected);
             if (isType(actualType) && isType(expectedType)) {
-                const comparisonResult = createTypeCheckStrategy(strategy, this.typir)(actualType, expectedType);
+                const strategyLogic = createTypeCheckStrategy(strategy, this.typir);
+                const comparisonResult = strategyLogic(actualType, expectedType);
                 if (comparisonResult !== undefined) {
                     if (negated) {
                         // everything is fine

--- a/packages/typir/src/features/validation.ts
+++ b/packages/typir/src/features/validation.ts
@@ -6,7 +6,7 @@
 
 import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { TypirProblem } from '../utils/utils-definitions.js';
+import { isConcreteTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
 import { TypeCheckStrategy, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
 
 export type Severity = 'error' | 'warning' | 'info' | 'hint';
@@ -19,11 +19,13 @@ export interface ValidationMessageDetails {
     message: string;
 }
 
-export interface ValidationProblem extends ValidationMessageDetails {
+export interface ValidationProblem extends ValidationMessageDetails, TypirProblem {
+    $problem: 'ValidationProblem';
     subProblems?: TypirProblem[];
 }
+export const ValidationProblem = 'ValidationProblem';
 export function isValidationProblem(problem: unknown): problem is ValidationProblem {
-    return typeof problem === 'object' && problem !== null && typeof (problem as ValidationProblem).severity === 'string' && (problem as ValidationProblem).message !== undefined;
+    return isConcreteTypirProblem(problem, ValidationProblem);
 }
 
 export type ValidationRule = (domainElement: unknown, typir: Typir) => ValidationProblem[];
@@ -78,6 +80,7 @@ export class DefaultValidationConstraints implements ValidationConstraints {
                     } else {
                         const details = message(actualType, expectedType);
                         return [{
+                            $problem: ValidationProblem,
                             domainElement: details.domainElement ?? domainNode,
                             domainProperty: details.domainProperty,
                             domainIndex: details.domainIndex,
@@ -90,6 +93,7 @@ export class DefaultValidationConstraints implements ValidationConstraints {
                     if (negated) {
                         const details = message(actualType, expectedType);
                         return [{
+                            $problem: ValidationProblem,
                             domainElement: details.domainElement ?? domainNode,
                             domainProperty: details.domainProperty,
                             domainIndex: details.domainIndex,

--- a/packages/typir/src/features/validation.ts
+++ b/packages/typir/src/features/validation.ts
@@ -81,7 +81,7 @@ export class DefaultValidationConstraints implements ValidationConstraints {
                             domainProperty: details.domainProperty,
                             domainIndex: details.domainIndex,
                             severity: details.severity ?? 'error',
-                            message: details.message ?? `'${actualType.name}' is ${negated ? '' : 'not '}related to '${expectedType.name}' regarding ${strategy}.`,
+                            message: details.message ?? `'${actualType.identifier}' is ${negated ? '' : 'not '}related to '${expectedType.identifier}' regarding ${strategy}.`,
                             subProblems: [comparisonResult]
                         }];
                     }
@@ -93,7 +93,7 @@ export class DefaultValidationConstraints implements ValidationConstraints {
                             domainProperty: details.domainProperty,
                             domainIndex: details.domainIndex,
                             severity: details.severity ?? 'error',
-                            message: details.message ?? `'${actualType.name}' is ${negated ? '' : 'not '}related to '${expectedType.name}' regarding ${strategy}.`,
+                            message: details.message ?? `'${actualType.identifier}' is ${negated ? '' : 'not '}related to '${expectedType.identifier}' regarding ${strategy}.`,
                             subProblems: [] // no sub-problems are available!
                         }];
                     } else {

--- a/packages/typir/src/graph/type-edge.ts
+++ b/packages/typir/src/graph/type-edge.ts
@@ -4,18 +4,16 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { CachingKind } from '../features/caching.js';
 import { Type } from './type-node.js';
 
-// TODO make TypeEdge abstract??
-export class TypeEdge {
+export interface TypeEdge {
+    readonly $meaning: string;
     readonly from: Type;
     readonly to: Type;
-    readonly meaning: string; // unique keys to indicate the meaning of this edge
-    readonly properties: Map<string, unknown> = new Map(); // store arbitrary data along edges
+    cachingInformation?: CachingKind;
+}
 
-    constructor(from: Type, to: Type, meaning: string) {
-        this.from = from;
-        this.to = to;
-        this.meaning = meaning;
-    }
+export function isTypeEdge(edge: unknown): edge is TypeEdge {
+    return typeof edge === 'object' && edge !== null && typeof (edge as TypeEdge).$meaning === 'string';
 }

--- a/packages/typir/src/graph/type-edge.ts
+++ b/packages/typir/src/graph/type-edge.ts
@@ -4,16 +4,30 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { CachingKind } from '../features/caching.js';
+import { EdgeCachingInformation } from '../features/caching.js';
 import { Type } from './type-node.js';
 
+/**
+ * An edge has a direction (from --> to) and can be querried from both types (incomingEdge, outgoingEdge).
+ * Between the same from and to nodes, edges with different $relations are allowed, but not multiple edges with the same $relation (in the same direction).
+ *
+ * Bidirectional relationships are represented by a single edge in the type graph,
+ * otherwise information stored along these edges must be duplicated and maintained.
+ * Edges don't contain explicit information, wether they are unidirectional or bidirectional, since it is semantically encoded in the $relation.
+ * Users of edges who know about the $relation also know, whether the corresponding edges are unidirectional or bidirectional.
+ * Graph algorithms also know, whether they work on unidirectional or on bidirectional edges.
+ *
+ * Edges are realized as interfaces (and not as classes), since there are no methods to reuse or to override for customizations.
+ */
 export interface TypeEdge {
-    readonly $meaning: string;
+    readonly $relation: string;
     readonly from: Type;
     readonly to: Type;
-    cachingInformation?: CachingKind;
+    /** The default value is 'LINK_EXISTS'.
+     * But edges might be used to explicitly indicate, that relationships are unclear or don't exist! */
+    cachingInformation: EdgeCachingInformation;
 }
 
 export function isTypeEdge(edge: unknown): edge is TypeEdge {
-    return typeof edge === 'object' && edge !== null && typeof (edge as TypeEdge).$meaning === 'string';
+    return typeof edge === 'object' && edge !== null && typeof (edge as TypeEdge).$relation === 'string';
 }

--- a/packages/typir/src/graph/type-edge.ts
+++ b/packages/typir/src/graph/type-edge.ts
@@ -6,6 +6,7 @@
 
 import { Type } from './type-node.js';
 
+// TODO make TypeEdge abstract??
 export class TypeEdge {
     readonly from: Type;
     readonly to: Type;

--- a/packages/typir/src/graph/type-graph.ts
+++ b/packages/typir/src/graph/type-graph.ts
@@ -12,7 +12,7 @@ export class TypeGraph {
     protected readonly edges: TypeEdge[] = [];
 
     addNode(type: Type): void {
-        const key = type.name;
+        const key = type.identifier;
         if (this.nodes.has(key)) {
             if (this.nodes.get(key) === type) {
                 // this type is already registered => that is OK
@@ -29,7 +29,7 @@ export class TypeGraph {
         type.getAllIncomingEdges().forEach(e => this.removeEdge(e));
         type.getAllOutgoingEdges().forEach(e => this.removeEdge(e));
         // remove the type itself
-        this.nodes.delete(type.name);
+        this.nodes.delete(type.identifier);
     }
 
     getNode(name: string): Type | undefined {

--- a/packages/typir/src/graph/type-graph.ts
+++ b/packages/typir/src/graph/type-graph.ts
@@ -4,12 +4,23 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { EdgeCachingInformation } from '../features/caching.js';
 import { TypeEdge } from './type-edge.js';
 import { Type } from './type-node.js';
 
+/**
+ * Each Typir instance has one single type graph.
+ * Each type exists only once and is stored inside this type graph.
+ *
+ * Edges with different meaning/purpose will exist in parallel inside the same graph,
+ * otherwise nodes/types need to be duplicated or would be used in multiple graphs.
+ * Graph algorithms will need to filter the required edges regarding $relation.
+ */
 export class TypeGraph {
+
     protected readonly nodes: Map<string, Type> = new Map(); // type name => Type
     protected readonly edges: TypeEdge[] = [];
+
 
     addNode(type: Type): void {
         const key = type.identifier;
@@ -39,7 +50,14 @@ export class TypeGraph {
         return this.getNode(name);
     }
 
+
     addEdge(edge: TypeEdge): void {
+        // check constraints: no duplicated edges (same values for: from, to, $relation)
+        if (edge.from.getOutgoingEdges(edge.$relation).some(e => e.to === edge.to)) {
+            throw new Error(`There is already a '${edge.$relation}' edge from '${edge.from.getName()}' to '${edge.to.getName()}'.`);
+        }
+        // TODO what about the other direction for bidirectional edges? for now, the user has to ensure no duplicates here!
+
         this.edges.push(edge);
 
         // register this new edge at the connected nodes
@@ -58,6 +76,16 @@ export class TypeGraph {
         edge.from.removeOutgoingEdge(edge);
     }
 
-    // add reusable graph algorithms here
+    getUnidirectionalEdge<T extends TypeEdge>(from: Type, to: Type, $relation: T['$relation'], cachingMode: EdgeCachingInformation = 'LINK_EXISTS'): T | undefined {
+        return from.getOutgoingEdges<T>($relation).find(edge => edge.to === to && edge.cachingInformation === cachingMode);
+    }
+
+    getBidirectionalEdge<T extends TypeEdge>(from: Type, to: Type, $relation: T['$relation'], cachingMode: EdgeCachingInformation = 'LINK_EXISTS'): T | undefined {
+        // for bidirectional edges, check outgoing and incoming edges, since the graph contains only a single edge!
+        return from.getEdges<T>($relation).find(edge => edge.to === to && edge.cachingInformation === cachingMode);
+    }
+
+
+    // add reusable graph algorithms here (or introduce a new service for graph algorithms which might be easier to customize/exchange)
 
 }

--- a/packages/typir/src/graph/type-node.ts
+++ b/packages/typir/src/graph/type-node.ts
@@ -27,7 +27,7 @@ export abstract class Type {
     readonly identifier: string;
 
     // this is required only to apply graph algorithms in a generic way!
-    // $meaning is used as key
+    // $relation is used as key
     protected readonly edgesIncoming: Map<string, TypeEdge[]> = new Map();
     protected readonly edgesOutgoing: Map<string, TypeEdge[]> = new Map();
 
@@ -64,6 +64,7 @@ export abstract class Type {
     /**
      * Analyzes, whether there is a sub type-relationship between two types.
      * The difference between sub type-relationships and super type-relationships are only switched types.
+     * If both types are the same, no problems will be reported, since a type is considered as sub-type of itself (by definition).
      *
      * @param superType the super type, while the current type is the sub type
      * @returns an empty array, if the relationship exists, otherwise some problems which might point to violations of the investigated relationship
@@ -73,6 +74,7 @@ export abstract class Type {
     /**
      * Analyzes, whether there is a super type-relationship between two types.
      * The difference between sub type-relationships and super type-relationships are only switched types.
+     * If both types are the same, no problems will be reported, since a type is considered as sub-type of itself (by definition).
      *
      * @param subType the sub type, while the current type is super type
      * @returns an empty array, if the relationship exists, otherwise some problems which might point to violations of the investigated relationship
@@ -81,7 +83,7 @@ export abstract class Type {
 
 
     addIncomingEdge(edge: TypeEdge): void {
-        const key = edge.$meaning;
+        const key = edge.$relation;
         if (this.edgesIncoming.has(key)) {
             this.edgesIncoming.get(key)!.push(edge);
         } else {
@@ -89,7 +91,7 @@ export abstract class Type {
         }
     }
     addOutgoingEdge(edge: TypeEdge): void {
-        const key = edge.$meaning;
+        const key = edge.$relation;
         if (this.edgesOutgoing.has(key)) {
             this.edgesOutgoing.get(key)!.push(edge);
         } else {
@@ -98,7 +100,7 @@ export abstract class Type {
     }
 
     removeIncomingEdge(edge: TypeEdge): boolean {
-        const key = edge.$meaning;
+        const key = edge.$relation;
         const list = this.edgesIncoming.get(key);
         if (list) {
             const index = list.indexOf(edge);
@@ -113,7 +115,7 @@ export abstract class Type {
         return false;
     }
     removeOutgoingEdge(edge: TypeEdge): boolean {
-        const key = edge.$meaning;
+        const key = edge.$relation;
         const list = this.edgesOutgoing.get(key);
         if (list) {
             const index = list.indexOf(edge);
@@ -128,11 +130,17 @@ export abstract class Type {
         return false;
     }
 
-    getIncomingEdges<T extends TypeEdge>($meaning: T['$meaning']): T[] {
-        return this.edgesIncoming.get($meaning) as T[] ?? [];
+    getIncomingEdges<T extends TypeEdge>($relation: T['$relation']): T[] {
+        return this.edgesIncoming.get($relation) as T[] ?? [];
     }
-    getOutgoingEdges<T extends TypeEdge>($meaning: T['$meaning']): T[] {
-        return this.edgesOutgoing.get($meaning) as T[] ?? [];
+    getOutgoingEdges<T extends TypeEdge>($relation: T['$relation']): T[] {
+        return this.edgesOutgoing.get($relation) as T[] ?? [];
+    }
+    getEdges<T extends TypeEdge>($relation: T['$relation']): T[] {
+        return [
+            ...this.getIncomingEdges($relation),
+            ...this.getOutgoingEdges($relation),
+        ];
     }
 
     getAllIncomingEdges(): TypeEdge[] {
@@ -140,6 +148,12 @@ export abstract class Type {
     }
     getAllOutgoingEdges(): TypeEdge[] {
         return Array.from(this.edgesOutgoing.values()).flat();
+    }
+    getAllEdges(): TypeEdge[] {
+        return [
+            ...this.getAllIncomingEdges(),
+            ...this.getAllOutgoingEdges(),
+        ];
     }
 }
 

--- a/packages/typir/src/graph/type-node.ts
+++ b/packages/typir/src/graph/type-node.ts
@@ -27,7 +27,7 @@ export abstract class Type {
     readonly identifier: string;
 
     // this is required only to apply graph algorithms in a generic way!
-    // is there a simplier solution to combine generic graph algoriths with specifc properties?
+    // $meaning is used as key
     protected readonly edgesIncoming: Map<string, TypeEdge[]> = new Map();
     protected readonly edgesOutgoing: Map<string, TypeEdge[]> = new Map();
 
@@ -70,7 +70,7 @@ export abstract class Type {
 
 
     addIncomingEdge(edge: TypeEdge): void {
-        const key = edge.meaning;
+        const key = edge.$meaning;
         if (this.edgesIncoming.has(key)) {
             this.edgesIncoming.get(key)!.push(edge);
         } else {
@@ -78,7 +78,7 @@ export abstract class Type {
         }
     }
     addOutgoingEdge(edge: TypeEdge): void {
-        const key = edge.meaning;
+        const key = edge.$meaning;
         if (this.edgesOutgoing.has(key)) {
             this.edgesOutgoing.get(key)!.push(edge);
         } else {
@@ -87,7 +87,7 @@ export abstract class Type {
     }
 
     removeIncomingEdge(edge: TypeEdge): boolean {
-        const key = edge.meaning;
+        const key = edge.$meaning;
         const list = this.edgesIncoming.get(key);
         if (list) {
             const index = list.indexOf(edge);
@@ -102,7 +102,7 @@ export abstract class Type {
         return false;
     }
     removeOutgoingEdge(edge: TypeEdge): boolean {
-        const key = edge.meaning;
+        const key = edge.$meaning;
         const list = this.edgesOutgoing.get(key);
         if (list) {
             const index = list.indexOf(edge);
@@ -117,11 +117,11 @@ export abstract class Type {
         return false;
     }
 
-    getIncomingEdges(key: string): TypeEdge[] {
-        return this.edgesIncoming.get(key) ?? [];
+    getIncomingEdges<T extends TypeEdge>($meaning: T['$meaning']): T[] {
+        return this.edgesIncoming.get($meaning) as T[] ?? [];
     }
-    getOutgoingEdges(key: string): TypeEdge[] {
-        return this.edgesOutgoing.get(key) ?? [];
+    getOutgoingEdges<T extends TypeEdge>($meaning: T['$meaning']): T[] {
+        return this.edgesOutgoing.get($meaning) as T[] ?? [];
     }
 
     getAllIncomingEdges(): TypeEdge[] {

--- a/packages/typir/src/graph/type-node.ts
+++ b/packages/typir/src/graph/type-node.ts
@@ -54,10 +54,12 @@ export abstract class Type {
      */
     abstract getUserRepresentation(): string;
 
+
     /**
      * Analyzes, whether two types are equal.
      * @param otherType to be compared with the current type
-     * @returns an empty array, if both types are equal, otherwise some problems which might point to found differences/conflicts between the two types
+     * @returns an empty array, if both types are equal, otherwise some problems which might point to found differences/conflicts between the two types.
+     * These problems are presented to users in order to support them with useful information about the result of this analysis.
      */
     abstract analyzeTypeEqualityProblems(otherType: Type): TypirProblem[];
 
@@ -67,7 +69,8 @@ export abstract class Type {
      * If both types are the same, no problems will be reported, since a type is considered as sub-type of itself (by definition).
      *
      * @param superType the super type, while the current type is the sub type
-     * @returns an empty array, if the relationship exists, otherwise some problems which might point to violations of the investigated relationship
+     * @returns an empty array, if the relationship exists, otherwise some problems which might point to violations of the investigated relationship.
+     * These problems are presented to users in order to support them with useful information about the result of this analysis.
      */
     abstract analyzeIsSubTypeOf(superType: Type): TypirProblem[];
 
@@ -77,7 +80,8 @@ export abstract class Type {
      * If both types are the same, no problems will be reported, since a type is considered as sub-type of itself (by definition).
      *
      * @param subType the sub type, while the current type is super type
-     * @returns an empty array, if the relationship exists, otherwise some problems which might point to violations of the investigated relationship
+     * @returns an empty array, if the relationship exists, otherwise some problems which might point to violations of the investigated relationship.
+     * These problems are presented to users in order to support them with useful information about the result of this analysis.
      */
     abstract analyzeIsSuperTypeOf(subType: Type): TypirProblem[];
 

--- a/packages/typir/src/graph/type-node.ts
+++ b/packages/typir/src/graph/type-node.ts
@@ -16,7 +16,7 @@ import { TypeEdge } from './type-edge.js';
 export abstract class Type {
     readonly kind: Kind; // => $kind: string, required for isXType() checks
     /**
-     * Identifiers must be unique and stable, since they are used as key to store types in maps.
+     * Identifiers must be unique and stable for all types known in a single Typir instance, since they are used as key to store types in maps.
      * Identifiers might have a naming schema for calculatable values.
      */
     /* Design decision for the name of this attribute
@@ -37,9 +37,20 @@ export abstract class Type {
 
 
     /**
+     * Returns a string value containing a short representation of the type to be shown to users of the type-checked elements.
+     * This value don't need to be unique for all types.
+     * This name should be quite short.
+     * Services should not call this function directly, but typir.printer.printTypeName(...) instead.
+     * @returns a short string value to show to the user
+     */
+    abstract getName(): string;
+
+    /**
      * Calculates a string value which might be shown to users of the type-checked elements.
      * This value don't need to be unique for all types.
-     * @returns a string value to show to the user
+     * This representation might be longer and show lots of details of the type.
+     * Services should not call this function directly, but typir.printer.printTypeUserRepresentation(...) instead.
+     * @returns a longer string value to show to the user
      */
     abstract getUserRepresentation(): string;
 
@@ -132,7 +143,6 @@ export abstract class Type {
     }
 }
 
-// TODO dies funktioniert mit Vererbung gar nicht richtig, oder? A extends B, funktioniert dann isA auf Instanzen von B??
 export function isType(type: unknown): type is Type {
     return typeof type === 'object' && type !== null && typeof (type as Type).identifier === 'string' && isKind((type as Type).kind);
 }

--- a/packages/typir/src/kinds/bottom-kind.ts
+++ b/packages/typir/src/kinds/bottom-kind.ts
@@ -11,7 +11,7 @@ import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { TypirProblem } from '../utils/utils-definitions.js';
 import { createKindConflict } from '../utils/utils-type-comparison.js';
-import { toArray } from '../utils/utils.js';
+import { assertTrue, toArray } from '../utils/utils.js';
 import { isKind, Kind } from './kind.js';
 
 export class BottomType extends Type {
@@ -115,6 +115,7 @@ export class BottomKind implements Kind {
     }
 
     createBottomType(typeDetails: BottomTypeDetails): BottomType {
+        assertTrue(this.getBottomType(typeDetails) === undefined);
         // create the bottom type (singleton)
         if (this.instance) {
             // note, that the given inference rules are ignored in this case!

--- a/packages/typir/src/kinds/bottom-kind.ts
+++ b/packages/typir/src/kinds/bottom-kind.ts
@@ -22,6 +22,10 @@ export class BottomType extends Type {
         this.kind = kind;
     }
 
+    override getName(): string {
+        return this.identifier;
+    }
+
     override getUserRepresentation(): string {
         return this.identifier;
     }

--- a/packages/typir/src/kinds/bottom-kind.ts
+++ b/packages/typir/src/kinds/bottom-kind.ts
@@ -1,0 +1,147 @@
+/******************************************************************************
+ * Copyright 2024 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+import { TypeEqualityProblem } from '../features/equality.js';
+import { InferenceRuleNotApplicable } from '../features/inference.js';
+import { SubTypeProblem } from '../features/subtype.js';
+import { isType, Type } from '../graph/type-node.js';
+import { Typir } from '../typir.js';
+import { TypirProblem } from '../utils/utils-definitions.js';
+import { createKindConflict } from '../utils/utils-type-comparison.js';
+import { toArray } from '../utils/utils.js';
+import { isKind, Kind } from './kind.js';
+
+export class BottomType extends Type {
+    override readonly kind: BottomKind;
+
+    constructor(kind: BottomKind, identifier: string) {
+        super(identifier);
+        this.kind = kind;
+    }
+
+    override getUserRepresentation(): string {
+        return this.identifier;
+    }
+
+    override analyzeTypeEqualityProblems(otherType: Type): TypirProblem[] {
+        if (isBottomType(otherType)) {
+            return [];
+        } else {
+            return [<TypeEqualityProblem>{
+                $problem: TypeEqualityProblem,
+                type1: this,
+                type2: otherType,
+                subProblems: [createKindConflict(this, otherType)],
+            }];
+        }
+    }
+
+    override analyzeIsSubTypeOf(_superType: Type): TypirProblem[] {
+        // a BottomType is the sub type of all types!
+        return [];
+    }
+
+    override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
+        if (isBottomType(subType)) {
+            // special case by definition: BottomType is sub-type of BottomType
+            return [];
+        } else {
+            return [<SubTypeProblem>{
+                $problem: SubTypeProblem,
+                superType: this,
+                subType: subType,
+                subProblems: [createKindConflict(this, subType)],
+            }];
+        }
+    }
+
+}
+
+export function isBottomType(type: unknown): type is BottomType {
+    return isType(type) && isBottomKind(type.kind);
+}
+
+
+
+export interface BottomTypeDetails {
+    /** In case of multiple inference rules, later rules are not evaluated anymore, if an earler rule already matched. */
+    inferenceRules?: InferBottomType | InferBottomType[]
+}
+
+export interface BottomKindOptions {
+    name: string;
+}
+
+export type InferBottomType = (domainElement: unknown) => boolean;
+
+export const BottomKindName = 'BottomKind';
+
+export class BottomKind implements Kind {
+    readonly $name: 'BottomKind';
+    readonly typir: Typir;
+    readonly options: BottomKindOptions;
+    protected instance: BottomType | undefined;
+
+    constructor(typir: Typir, options?: Partial<BottomKindOptions>) {
+        this.$name = BottomKindName;
+        this.typir = typir;
+        this.typir.registerKind(this);
+        this.options = {
+            // the default values:
+            name: 'never',
+            // the actually overriden values:
+            ...options
+        };
+    }
+
+    getBottomType(typeDetails: BottomTypeDetails): BottomType | undefined {
+        const key = this.calculateIdentifier(typeDetails);
+        return this.typir.graph.getType(key) as BottomType;
+    }
+
+    getOrCreateBottomType(typeDetails: BottomTypeDetails): BottomType {
+        const result = this.getBottomType(typeDetails);
+        if (result) {
+            return result;
+        }
+        return this.createBottomType(typeDetails);
+    }
+
+    createBottomType(typeDetails: BottomTypeDetails): BottomType {
+        // create the bottom type (singleton)
+        if (this.instance) {
+            // note, that the given inference rules are ignored in this case!
+            return this.instance;
+        }
+        const bottomType = new BottomType(this, this.calculateIdentifier(typeDetails));
+        this.instance = bottomType;
+        this.typir.graph.addNode(bottomType);
+
+        // register all inference rules for primitives within a single generic inference rule (in order to keep the number of "global" inference rules small)
+        const rules = toArray(typeDetails.inferenceRules);
+        if (rules.length >= 1) {
+            this.typir.inference.addInferenceRule((domainElement, _typir) => {
+                for (const inferenceRule of rules) {
+                    if (inferenceRule(domainElement)) {
+                        return bottomType;
+                    }
+                }
+                return InferenceRuleNotApplicable;
+            });
+        }
+
+        return bottomType;
+    }
+
+    calculateIdentifier(_typeDetails: BottomTypeDetails): string {
+        return this.options.name;
+    }
+
+}
+
+export function isBottomKind(kind: unknown): kind is BottomKind {
+    return isKind(kind) && kind.$name === BottomKindName;
+}

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -86,6 +86,7 @@ export class ClassType extends Type {
             }
         } else {
             return [<TypeEqualityProblem>{
+                $problem: TypeEqualityProblem,
                 type1: this,
                 type2: otherType,
                 subProblems: [createKindConflict(otherType, this)],
@@ -98,6 +99,7 @@ export class ClassType extends Type {
             return this.analyzeSubTypeProblems(this, superType);
         }
         return [<SubTypeProblem>{
+            $problem: SubTypeProblem,
             superType,
             subType: this,
             subProblems: [createKindConflict(this, superType)],
@@ -109,6 +111,7 @@ export class ClassType extends Type {
             return this.analyzeSubTypeProblems(subType, this);
         }
         return [<SubTypeProblem>{
+            $problem: SubTypeProblem,
             superType: this,
             subType,
             subProblems: [createKindConflict(subType, this)],
@@ -128,6 +131,7 @@ export class ClassType extends Type {
                     const subTypeComparison = checkStrategy(subFieldType, superFieldType);
                     if (subTypeComparison !== undefined) {
                         conflicts.push({
+                            $problem: IndexedTypeConflict,
                             expected: superType,
                             actual: subType,
                             index: superFieldName,
@@ -139,6 +143,7 @@ export class ClassType extends Type {
                 } else {
                     // missing sub field
                     conflicts.push({
+                        $problem: IndexedTypeConflict,
                         expected: superFieldType,
                         actual: undefined,
                         index: superFieldName,
@@ -361,6 +366,7 @@ export class ClassKind implements Kind {
                         return fieldType;
                     }
                     return <InferenceProblem>{
+                        $problem: InferenceProblem,
                         domainElement,
                         inferenceCandidate: classType,
                         location: `unknown field '${result}'`,
@@ -411,6 +417,7 @@ export class ClassKind implements Kind {
                 if (checkedFieldsProblems.length >= 1) {
                     // (only) for overloaded functions, the types of the parameters need to be inferred in order to determine an exact match
                     return <InferenceProblem>{
+                        $problem: InferenceProblem,
                         domainElement,
                         inferenceCandidate: classType,
                         location: 'values for fields',

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -317,7 +317,7 @@ export class ClassKind implements Kind {
     }
 
     getClassType(typeDetails: ClassTypeDetails | string): ClassType | undefined { // string for nominal typing
-        const key = this.printClassType(typeof typeDetails === 'string' ? { className: typeDetails, fields: []} : typeDetails);
+        const key = this.calculateIdentifier(typeof typeDetails === 'string' ? { className: typeDetails, fields: []} : typeDetails);
         return this.typir.graph.getType(key) as ClassType;
     }
 

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -75,7 +75,7 @@ export class ClassType extends Type {
 
     override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
         if (isClassType(superType)) {
-            this.analyzeSubTypeProblems(this, superType);
+            return this.analyzeSubTypeProblems(this, superType);
         }
         return [<SubTypeProblem>{
             superType,
@@ -86,7 +86,7 @@ export class ClassType extends Type {
 
     override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
         if (isClassType(subType)) {
-            this.analyzeSubTypeProblems(subType, this);
+            return this.analyzeSubTypeProblems(subType, this);
         }
         return [<SubTypeProblem>{
             superType: this,

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -97,25 +97,27 @@ export class ClassType extends Type {
     override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
         if (isClassType(superType)) {
             return this.analyzeSubTypeProblems(this, superType);
+        } else {
+            return [<SubTypeProblem>{
+                $problem: SubTypeProblem,
+                superType,
+                subType: this,
+                subProblems: [createKindConflict(this, superType)],
+            }];
         }
-        return [<SubTypeProblem>{
-            $problem: SubTypeProblem,
-            superType,
-            subType: this,
-            subProblems: [createKindConflict(this, superType)],
-        }];
     }
 
     override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
         if (isClassType(subType)) {
             return this.analyzeSubTypeProblems(subType, this);
+        } else {
+            return [<SubTypeProblem>{
+                $problem: SubTypeProblem,
+                superType: this,
+                subType,
+                subProblems: [createKindConflict(subType, this)],
+            }];
         }
-        return [<SubTypeProblem>{
-            $problem: SubTypeProblem,
-            superType: this,
-            subType,
-            subProblems: [createKindConflict(subType, this)],
-        }];
     }
 
     protected analyzeSubTypeProblems(subType: ClassType, superType: ClassType): TypirProblem[] {

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -59,15 +59,19 @@ export class ClassType extends Type {
         }
     }
 
+    override getName(): string {
+        return `${this.className}`;
+    }
+
     override getUserRepresentation(): string {
         // fields
         const fields: string[] = [];
         for (const field of this.getFields(false).entries()) {
-            fields.push(`${field[0]}: ${field[1].getUserRepresentation()}`); // TODO short vs long representation!! name vs identifier!
+            fields.push(`${field[0]}: ${field[1].getName()}`);
         }
         // super classes
         const superClasses = this.getDeclaredSuperClasses();
-        const extendedClasses = superClasses.length <= 0 ? '' : ` extends ${superClasses.map(c => c.getUserRepresentation()).join(', ')}`;
+        const extendedClasses = superClasses.length <= 0 ? '' : ` extends ${superClasses.map(c => c.getName()).join(', ')}`;
         // whole representation
         return `${this.className} { ${fields.join(', ')} }${extendedClasses}`;
     }

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -18,8 +18,9 @@ import { Kind, isKind } from './kind.js';
 export class ClassType extends Type {
     override readonly kind: ClassKind;
     readonly className: string;
-    protected readonly superClasses: ClassType[]; // if necessary, the array could be replaced by Map<string, ClassType>: name/form -> ClassType, for faster look-ups
-    protected readonly subClasses: ClassType[] = [];
+    /** The super classes are readonly, since they might be used to calculate the identifier of the current class, which must be stable. */
+    protected readonly superClasses: readonly ClassType[]; // if necessary, the array could be replaced by Map<string, ClassType>: name/form -> ClassType, for faster look-ups
+    protected readonly subClasses: ClassType[] = []; // additional sub classes might be added later on!
     protected readonly fields: FieldDetails[];
 
     constructor(kind: ClassKind, identifier: string, typeDetails: ClassTypeDetails) {
@@ -174,7 +175,7 @@ export class ClassType extends Type {
         }
     }
 
-    getDeclaredSuperClasses(): ClassType[] {
+    getDeclaredSuperClasses(): readonly ClassType[] {
         return this.superClasses;
     }
 

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -140,7 +140,7 @@ export class ClassType extends Type {
                             $problem: IndexedTypeConflict,
                             expected: superType,
                             actual: subType,
-                            index: superFieldName,
+                            propertyName: superFieldName,
                             subProblems: [subTypeComparison],
                         });
                     } else {
@@ -152,7 +152,7 @@ export class ClassType extends Type {
                         $problem: IndexedTypeConflict,
                         expected: superFieldType,
                         actual: undefined,
-                        index: superFieldName,
+                        propertyName: superFieldName,
                         subProblems: []
                     });
                 }

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -334,6 +334,8 @@ export class ClassKind implements Kind {
     }
 
     createClassType<T1, T2>(typeDetails: CreateClassTypeDetails<T1, T2>): ClassType {
+        assertTrue(this.getClassType(typeDetails) === undefined);
+
         // create the class type
         const classType = new ClassType(this, this.calculateIdentifier(typeDetails), typeDetails);
         this.typir.graph.addNode(classType);

--- a/packages/typir/src/kinds/class-kind.ts
+++ b/packages/typir/src/kinds/class-kind.ts
@@ -5,15 +5,221 @@
  ******************************************************************************/
 
 import { assertUnreachable } from 'langium';
+import { TypeEqualityProblem } from '../features/equality.js';
 import { InferenceProblem, InferenceRuleNotApplicable } from '../features/inference.js';
 import { SubTypeProblem } from '../features/subtype.js';
-import { TypeEdge } from '../graph/type-edge.js';
-import { Type } from '../graph/type-node.js';
+import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { IndexedTypeConflict, MapListConverter, TypeCheckStrategy, checkNameTypesMap, checkValueForConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
-import { assertKind, assertTrue, toArray } from '../utils/utils.js';
+import { TypeSelector, TypirProblem, resolveTypeSelector } from '../utils/utils-definitions.js';
+import { IndexedTypeConflict, MapListConverter, TypeCheckStrategy, checkNameTypesMap, checkValueForConflict, createKindConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
+import { assertTrue, assertType, toArray } from '../utils/utils.js';
 import { Kind, isKind } from './kind.js';
-import { resolveTypeSelector, TypeSelector, TypirProblem } from '../utils/utils-definitions.js';
+
+export class ClassType extends Type {
+    override readonly kind: ClassKind;
+    readonly className: string;
+    readonly superClasses: ClassType[];
+    readonly fields: FieldDetails[];
+
+    constructor(kind: ClassKind, identifier: string, typeDetails: ClassTypeDetails) {
+        super(identifier);
+        this.kind = kind;
+        this.className = typeDetails.className;
+        this.superClasses = toArray(typeDetails.superClasses).map(superr => {
+            const cls = resolveTypeSelector(this.kind.typir, superr);
+            assertType(cls, isClassType);
+            return cls;
+        });
+        this.fields = typeDetails.fields.map(field => {
+            const type = resolveTypeSelector(this.kind.typir, field);
+            return <FieldDetails>{
+                name: field.name,
+                type,
+            };
+        });
+    }
+
+    override getUserRepresentation(): string {
+        // fields
+        const fields: string[] = [];
+        for (const field of this.getFields(false).entries()) {
+            fields.push(`${field[0]}: ${field[1].getUserRepresentation()}`); // TODO short vs long representation!! name vs identifier!
+        }
+        // super classes
+        const superClasses = this.getDeclaredSuperClasses();
+        const extendedClasses = superClasses.length <= 0 ? '' : ` extends ${superClasses.map(c => c.getUserRepresentation()).join(', ')}`;
+        // whole representation
+        return `${this.className} { ${fields.join(', ')} }${extendedClasses}`;
+    }
+
+    override analyzeTypeEqualityProblems(otherType: Type): TypirProblem[] {
+        if (isClassType(otherType)) {
+            if (this.kind.options.typing === 'Structural') {
+                // for structural typing:
+                return checkNameTypesMap(this.getFields(true), otherType.getFields(true), // including fields of super-classes
+                    (t1, t2) => this.kind.typir.equality.getTypeEqualityProblem(t1, t2));
+            } else if (this.kind.options.typing === 'Nominal') {
+                // for nominal typing:
+                return checkValueForConflict(this.identifier, otherType.identifier, 'name');
+            } else {
+                assertUnreachable(this.kind.options.typing);
+            }
+        } else {
+            return [<TypeEqualityProblem>{
+                type1: this,
+                type2: otherType,
+                subProblems: [createKindConflict(otherType, this)],
+            }];
+        }
+    }
+
+    override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
+        if (isClassType(superType)) {
+            this.analyzeSubTypeProblems(this, superType);
+        }
+        return [<SubTypeProblem>{
+            superType,
+            subType: this,
+            subProblems: [createKindConflict(this, superType)],
+        }];
+    }
+
+    override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
+        if (isClassType(subType)) {
+            this.analyzeSubTypeProblems(subType, this);
+        }
+        return [<SubTypeProblem>{
+            superType: this,
+            subType,
+            subProblems: [createKindConflict(subType, this)],
+        }];
+    }
+
+    protected analyzeSubTypeProblems(subType: ClassType, superType: ClassType): TypirProblem[] {
+        if (this.kind.options.typing === 'Structural') {
+            // for structural typing, the sub type needs to have all fields of the super type with assignable types (including fields of all super classes):
+            const conflicts: IndexedTypeConflict[] = [];
+            const subFields = subType.getFields(true);
+            for (const [superFieldName, superFieldType] of superType.getFields(true)) {
+                if (subFields.has(superFieldName)) {
+                    // field is both in super and sub
+                    const subFieldType = subFields.get(superFieldName)!;
+                    const checkStrategy = createTypeCheckStrategy(this.kind.options.subtypeFieldChecking, this.kind.typir);
+                    const subTypeComparison = checkStrategy(subFieldType, superFieldType);
+                    if (subTypeComparison !== undefined) {
+                        conflicts.push({
+                            expected: superType,
+                            actual: subType,
+                            index: superFieldName,
+                            subProblems: [subTypeComparison],
+                        });
+                    } else {
+                        // everything is fine
+                    }
+                } else {
+                    // missing sub field
+                    conflicts.push({
+                        expected: superFieldType,
+                        actual: undefined,
+                        index: superFieldName,
+                        subProblems: []
+                    });
+                }
+            }
+            // Note that it is not necessary to check, whether the sub class has additional fields than the super type!
+            return conflicts;
+        } else if (this.kind.options.typing === 'Nominal') {
+            // for nominal typing (takes super classes into account)
+            const allSub = subType.getAllSuperClasses(true);
+            const globalResult: TypirProblem[] = [];
+            for (const oneSub of allSub) {
+                const localResult = checkValueForConflict(superType.identifier, oneSub.identifier, 'name'); // TODO use equals instead??
+                if (localResult.length <= 0) {
+                    return []; // class is found in the class hierarchy
+                }
+                globalResult.push(...localResult); // return all conflicts, TODO: is that too much??
+            }
+            return globalResult;
+        } else {
+            assertUnreachable(this.kind.options.typing);
+        }
+    }
+
+    getDeclaredSuperClasses(): ClassType[] {
+        return this.superClasses;
+    }
+
+    getDeclaredSubClasses(): ClassType[] {
+        // TODO
+        return [];
+    }
+
+    getAllSuperClasses(includingGivenClass: boolean = false): Set<ClassType> {
+        const result = new Set<ClassType>();
+        if (includingGivenClass) {
+            result.add(this);
+        }
+        const toadd = [...this.getDeclaredSuperClasses()];
+        while (toadd.length >= 1) {
+            const current = toadd.pop()!;
+            if (result.has(current)) {
+                // nothing to do
+            } else {
+                // found a new super class
+                result.add(current);
+                // ... and add its super classes as well
+                toadd.push(...current.getDeclaredSuperClasses());
+            }
+        }
+        return result;
+        // Sets preserve insertion order:
+        // return Array.from(set);
+    }
+
+    getAllSubClasses(includingGivenClass: boolean = false): Set<ClassType> {
+        const result = new Set<ClassType>();
+        if (includingGivenClass) {
+            result.add(this);
+        }
+        const toadd = [...this.getDeclaredSubClasses()];
+        while (toadd.length >= 1) {
+            const current = toadd.pop()!;
+            if (result.has(current)) {
+                // nothing to do
+            } else {
+                // found a new sub class
+                result.add(current);
+                // ... and add its sub classes as well
+                toadd.push(...current.getDeclaredSubClasses());
+            }
+        }
+        return result;
+    }
+
+    getFields(withSuperClassesFields: boolean): Map<string, Type> {
+        // in case of conflicting field names, the type of the sub-class takes precedence! TODO check this
+        const result = new Map();
+        // fields of super classes
+        if (withSuperClassesFields) {
+            for (const superClass of this.getDeclaredSuperClasses()) {
+                for (const [superName, superType] of superClass.getFields(true)) {
+                    result.set(superName, superType);
+                }
+            }
+        }
+        // own fields
+        this.fields.forEach(edge => {
+            result.set(edge.name, edge.type);
+        });
+        return result;
+    }
+}
+
+export function isClassType(type: unknown): type is ClassType {
+    return isType(type) && isClassKind(type.kind);
+}
+
+
 
 export interface ClassKindOptions {
     typing: 'Structural' | 'Nominal', // JS classes are nominal, TS structures are structural
@@ -28,14 +234,20 @@ export const ClassKindName = 'ClassKind';
 
 export interface FieldDetails {
     name: string;
+    type: Type;
+}
+export interface CreateFieldDetails {
+    name: string;
     type: TypeSelector;
 }
 
-export interface ClassTypeDetails<T1 = unknown, T2 = unknown> { // TODO the generics look very bad!
+export interface ClassTypeDetails {
     className: string,
     superClasses?: TypeSelector | TypeSelector[],
-    fields: FieldDetails[],
+    fields: CreateFieldDetails[],
     // TODO methods
+}
+export interface CreateClassTypeDetails<T1 = unknown, T2 = unknown> extends ClassTypeDetails { // TODO the generics look very bad!
     inferenceRuleForDeclaration?: (domainElement: unknown) => boolean, // TODO what is the purpose for this? what is the difference to literals?
     inferenceRuleForLiteral?: InferClassLiteral<T1>, // InferClassLiteral<T> | Array<InferClassLiteral<T>>, does not work: https://stackoverflow.com/questions/65129070/defining-an-array-of-differing-generic-types-in-typescript
     inferenceRuleForReference?: InferClassLiteral<T2>,
@@ -63,7 +275,7 @@ export class ClassKind implements Kind {
     readonly options: ClassKindOptions;
 
     constructor(typir: Typir, options?: Partial<ClassKindOptions>) {
-        this.$name = 'ClassKind';
+        this.$name = ClassKindName;
         this.typir = typir;
         this.typir.registerKind(this);
         this.options = {
@@ -78,12 +290,12 @@ export class ClassKind implements Kind {
         assertTrue(this.options.maximumNumberOfSuperClasses >= 0); // no negative values
     }
 
-    getClassType<T1, T2>(typeDetails: ClassTypeDetails<T1, T2> | string): Type | undefined { // string for nominal typing
+    getClassType(typeDetails: ClassTypeDetails | string): ClassType | undefined { // string for nominal typing
         const key = this.printClassType(typeof typeDetails === 'string' ? { className: typeDetails, fields: []} : typeDetails);
-        return this.typir.graph.getType(key);
+        return this.typir.graph.getType(key) as ClassType;
     }
 
-    getOrCreateClassType<T1, T2>(typeDetails: ClassTypeDetails<T1, T2>): Type {
+    getOrCreateClassType<T1, T2>(typeDetails: CreateClassTypeDetails<T1, T2>): ClassType {
         const result = this.getClassType(typeDetails);
         if (result) {
             return result;
@@ -91,31 +303,20 @@ export class ClassKind implements Kind {
         return this.createClassType(typeDetails);
     }
 
-    createClassType<T1, T2>(typeDetails: ClassTypeDetails<T1, T2>): Type {
-        const theSuperClasses = toArray(typeDetails.superClasses);
-        // eslint-disable-next-line @typescript-eslint/no-this-alias
-        const classKind = this;
-
+    createClassType<T1, T2>(typeDetails: CreateClassTypeDetails<T1, T2>): ClassType {
         // create the class type
-        const classType = new Type(this, this.printClassType(typeDetails));
+        const classType = new ClassType(this, this.calculateIdentifier(typeDetails), typeDetails);
         this.typir.graph.addNode(classType);
 
+        // TODO move these checks to another location!
         // FIELDS
-        // link it to all its "field types"
-        for (const fieldInfos of typeDetails.fields) {
-            // new edge between class and field with "semantics key"
-            const fieldType = resolveTypeSelector(this.typir, fieldInfos.type);
-            const edge = new TypeEdge(classType, fieldType, FIELD_TYPE);
-            // store the name of the field within the edge
-            edge.properties.set(FIELD_NAME, fieldInfos.name);
-            this.typir.graph.addEdge(edge);
-        }
         // check collisions of field names
-        if (this.getFields(classType, false).size !== typeDetails.fields.length) {
+        if (classType.getFields(false).size !== typeDetails.fields.length) {
             throw new Error('field names must be unique!');
         }
 
         // SUB-SUPER-CLASSES
+        const theSuperClasses = toArray(typeDetails.superClasses);
         // check number of allowed super classes
         if (this.options.maximumNumberOfSuperClasses >= 0) {
             if (this.options.maximumNumberOfSuperClasses < theSuperClasses.length) {
@@ -125,18 +326,10 @@ export class ClassKind implements Kind {
         // check cycles
         for (const superDetails of theSuperClasses) {
             const superClass = resolveTypeSelector(this.typir, superDetails);
-            if (this.getAllSuperClasses(superClass, true).has(classType)) {
+            assertType(superClass, isClassType);
+            if (superClass.getAllSuperClasses(true).has(classType)) {
                 throw new Error('Circle in super-sub-class-relationships are not allowed.');
             }
-        }
-        // link the new class to all its super classes
-        for (const superDetails of theSuperClasses) {
-            const superClass = resolveTypeSelector(this.typir, superDetails);
-            if (superClass.kind.$name !== classType.kind.$name) {
-                throw new Error();
-            }
-            const edge = new TypeEdge(classType, superClass, SUPER_CLASS);
-            this.typir.graph.addEdge(edge);
         }
 
         // register inference rules
@@ -156,10 +349,10 @@ export class ClassKind implements Kind {
             });
         }
         if (typeDetails.inferenceRuleForLiteral) {
-            this.registerInferenceRule(typeDetails.inferenceRuleForLiteral, classKind, classType);
+            this.registerInferenceRule(typeDetails.inferenceRuleForLiteral, this, classType);
         }
         if (typeDetails.inferenceRuleForReference) {
-            this.registerInferenceRule(typeDetails.inferenceRuleForReference, classKind, classType);
+            this.registerInferenceRule(typeDetails.inferenceRuleForReference, this, classType);
         }
         if (typeDetails.inferenceRuleForFieldAccess) {
             this.typir.inference.addInferenceRule((domainElement, _typir) => {
@@ -168,7 +361,7 @@ export class ClassKind implements Kind {
                     return InferenceRuleNotApplicable;
                 } else if (typeof result === 'string') {
                     // get the type of the given field name
-                    const fieldType = classKind.getFields(classType, true).get(result);
+                    const fieldType = classType.getFields(true).get(result);
                     if (fieldType) {
                         return fieldType;
                     }
@@ -188,7 +381,7 @@ export class ClassKind implements Kind {
         return classType;
     }
 
-    protected registerInferenceRule<T>(rule: InferClassLiteral<T>, classKind: ClassKind, classType: Type): void {
+    protected registerInferenceRule<T>(rule: InferClassLiteral<T>, classKind: ClassKind, classType: ClassType): void {
         const mapListConverter = new MapListConverter();
         this.typir.inference.addInferenceRule({
             inferTypeWithoutChildren(domainElement, _typir) {
@@ -213,7 +406,7 @@ export class ClassKind implements Kind {
                 return InferenceRuleNotApplicable;
             },
             inferTypeWithChildrensTypes(domainElement, childrenTypes, typir) {
-                const allExpectedFields = classKind.getFields(classType, true);
+                const allExpectedFields = classType.getFields(true);
                 // this class type might match, to be sure, resolve the types of the values for the parameters and continue to step 2
                 const checkedFieldsProblems = checkNameTypesMap(
                     mapListConverter.toMap(childrenTypes),
@@ -237,7 +430,11 @@ export class ClassKind implements Kind {
         });
     }
 
-    protected printClassType<T1, T2>(typeDetails: ClassTypeDetails<T1, T2>): string {
+    calculateIdentifier(typeDetails: ClassTypeDetails): string {
+        return this.printClassType(typeDetails);
+    }
+
+    protected printClassType(typeDetails: ClassTypeDetails): string {
         const prefix = this.options.identifierPrefix;
         if (this.options.typing === 'Structural') {
             // fields
@@ -246,8 +443,12 @@ export class ClassKind implements Kind {
                 fields.push(`${fieldNUmber}:${fieldDetails.name}`);
             }
             // super classes
-            const superClasses = toArray(typeDetails.superClasses).map(selector => resolveTypeSelector(this.typir, selector));
-            const extendedClasses = superClasses.length <= 0 ? '' : `-extends-${superClasses.map(c => c.name).join(',')}`;
+            const superClasses = toArray(typeDetails.superClasses).map(selector => {
+                const type = resolveTypeSelector(this.typir, selector);
+                assertType(type, isClassType);
+                return type;
+            });
+            const extendedClasses = superClasses.length <= 0 ? '' : `-extends-${superClasses.map(c => c.identifier).join(',')}`;
             // whole representation
             return `${prefix}-${typeDetails.className}{${fields.join(',')}}${extendedClasses}`;
         } else if (this.options.typing === 'Nominal') {
@@ -257,172 +458,7 @@ export class ClassKind implements Kind {
         }
     }
 
-    getUserRepresentation(type: Type): string {
-        assertKind(type.kind, isClassKind);
-        // fields
-        const fields: string[] = [];
-        for (const field of this.getFields(type, false).entries()) {
-            fields.push(`${field[0]}: ${field[1].name}`);
-        }
-        // super classes
-        const superClasses = this.getDeclaredSuperClasses(type);
-        const extendedClasses = superClasses.length <= 0 ? '' : ` extends ${superClasses.map(c => c.name).join(', ')}`;
-        // whole representation
-        return `${type.name} { ${fields.join(', ')} }${extendedClasses}`;
-    }
-
-    analyzeSubTypeProblems(subType: Type, superType: Type): TypirProblem[] {
-        if (isClassKind(superType.kind) && isClassKind(subType.kind)) {
-            if (this.options.typing === 'Structural') {
-                // for structural typing, the sub type needs to have all fields of the super type with assignable types (including fields of all super classes):
-                const conflicts: IndexedTypeConflict[] = [];
-                const subFields = subType.kind.getFields(subType, true);
-                for (const [superFieldName, superFieldType] of superType.kind.getFields(superType, true)) {
-                    if (subFields.has(superFieldName)) {
-                        // field is both in super and sub
-                        const subFieldType = subFields.get(superFieldName)!;
-                        const checkStrategy = createTypeCheckStrategy(this.options.subtypeFieldChecking, this.typir);
-                        const subTypeComparison = checkStrategy(subFieldType, superFieldType);
-                        if (subTypeComparison !== undefined) {
-                            conflicts.push({
-                                expected: superType,
-                                actual: subType,
-                                index: superFieldName,
-                                subProblems: [subTypeComparison],
-                            });
-                        } else {
-                            // everything is fine
-                        }
-                    } else {
-                        // missing sub field
-                        conflicts.push({
-                            expected: superFieldType,
-                            actual: undefined,
-                            index: superFieldName,
-                            subProblems: []
-                        });
-                    }
-                }
-                // Note that it is not necessary to check, whether the sub class has additional fields than the super type!
-                return conflicts;
-            } else if (this.options.typing === 'Nominal') {
-                // for nominal typing (takes super classes into account)
-                const allSub = this.getAllSuperClasses(subType, true);
-                const globalResult: TypirProblem[] = [];
-                for (const oneSub of allSub) {
-                    const localResult = checkValueForConflict(superType.name, oneSub.name, 'name');
-                    if (localResult.length <= 0) {
-                        return []; // class is found in the class hierarchy
-                    }
-                    globalResult.push(...localResult); // return all conflicts
-                }
-                return globalResult;
-            } else {
-                assertUnreachable(this.options.typing);
-            }
-        }
-        return [<SubTypeProblem>{
-            superType,
-            subType,
-            subProblems: checkValueForConflict(superType.kind.$name, subType.kind.$name, 'kind'),
-        }];
-    }
-
-    analyzeTypeEqualityProblems(type1: Type, type2: Type): TypirProblem[] {
-        if (isClassKind(type1.kind) && isClassKind(type2.kind)) {
-            if (this.options.typing === 'Structural') {
-                // for structural typing:
-                return checkNameTypesMap(type1.kind.getFields(type1, true), type2.kind.getFields(type2, true),
-                    (t1, t2) => this.typir.equality.getTypeEqualityProblem(t1, t2));
-            } else if (this.options.typing === 'Nominal') {
-                // for nominal typing:
-                return checkValueForConflict(type1.name, type2.name, 'name');
-            } else {
-                assertUnreachable(this.options.typing);
-            }
-        }
-        throw new Error();
-    }
-
-    getDeclaredSuperClasses(classType: Type): Type[] {
-        assertKind(classType.kind, isClassKind);
-        return classType.getOutgoingEdges(SUPER_CLASS).map(edge => edge.to);
-    }
-
-    getDeclaredSubClasses(classType: Type): Type[] {
-        assertKind(classType.kind, isClassKind);
-        return classType.getIncomingEdges(SUPER_CLASS).map(edge => edge.from);
-    }
-
-    getAllSuperClasses(classType: Type, includingGivenClass: boolean = false): Set<Type> {
-        assertKind(classType.kind, isClassKind);
-        const result = new Set<Type>();
-        if (includingGivenClass) {
-            result.add(classType);
-        }
-        const toadd = this.getDeclaredSuperClasses(classType);
-        while (toadd.length >= 1) {
-            const current = toadd.pop()!;
-            if (result.has(current)) {
-                // nothing to do
-            } else {
-                // found a new super class
-                result.add(current);
-                // ... and add its super classes as well
-                toadd.push(...this.getDeclaredSuperClasses(current));
-            }
-        }
-        return result;
-        // Sets preserve insertion order:
-        // return Array.from(set);
-    }
-
-    getAllSubClasses(classType: Type, includingGivenClass: boolean = false): Set<Type> {
-        assertKind(classType.kind, isClassKind);
-        const result = new Set<Type>();
-        if (includingGivenClass) {
-            result.add(classType);
-        }
-        const toadd = this.getDeclaredSubClasses(classType);
-        while (toadd.length >= 1) {
-            const current = toadd.pop()!;
-            if (result.has(current)) {
-                // nothing to do
-            } else {
-                // found a new sub class
-                result.add(current);
-                // ... and add its sub classes as well
-                toadd.push(...this.getDeclaredSubClasses(current));
-            }
-        }
-        return result;
-    }
-
-    getFields(classType: Type, withSuperClassesFields: boolean): Map<string, Type> {
-        assertKind(classType.kind, isClassKind);
-        // in case of conflicting field names, the type of the sub-class takes precedence! TODO
-        const result = new Map();
-        // fields of super classes
-        if (withSuperClassesFields) {
-            for (const superClass of this.getDeclaredSuperClasses(classType)) {
-                for (const [superName, superType] of this.getFields(superClass, true)) {
-                    result.set(superName, superType);
-                }
-            }
-        }
-        // own fields
-        classType.getOutgoingEdges(FIELD_TYPE).forEach(edge => {
-            const name = edge.properties.get(FIELD_NAME);
-            const type = edge.to;
-            result.set(name, type);
-        });
-        return result;
-    }
 }
-
-const FIELD_TYPE = 'hasField';
-const FIELD_NAME = 'name';
-const SUPER_CLASS = 'isSuperClass';
 
 export function isClassKind(kind: unknown): kind is ClassKind {
     return isKind(kind) && kind.$name === ClassKindName;

--- a/packages/typir/src/kinds/fixed-parameters-kind.ts
+++ b/packages/typir/src/kinds/fixed-parameters-kind.ts
@@ -9,7 +9,7 @@ import { SubTypeProblem } from '../features/subtype.js';
 import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { TypirProblem } from '../utils/utils-definitions.js';
-import { TypeCheckStrategy, checkTypes, checkValueForConflict, createKindConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
+import { TypeCheckStrategy, checkTypeArrays, checkValueForConflict, createKindConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
 import { assertTrue, toArray } from '../utils/utils.js';
 import { Kind, isKind } from './kind.js';
 
@@ -73,7 +73,7 @@ export class FixedParameterType extends Type {
             } else {
                 // all parameter types must match, e.g. Set<String> !== Set<Boolean>
                 const conflicts: TypirProblem[] = [];
-                conflicts.push(...checkTypes(this.getParameterTypes(), otherType.getParameterTypes(), (t1, t2) => this.kind.typir.equality.getTypeEqualityProblem(t1, t2)));
+                conflicts.push(...checkTypeArrays(this.getParameterTypes(), otherType.getParameterTypes(), (t1, t2) => this.kind.typir.equality.getTypeEqualityProblem(t1, t2), false));
                 return conflicts;
             }
         } else {
@@ -121,7 +121,7 @@ export class FixedParameterType extends Type {
         } else {
             // all parameter types must match, e.g. Set<String> !== Set<Boolean>
             const checkStrategy = createTypeCheckStrategy(this.kind.options.parameterSubtypeCheckingStrategy, this.kind.typir);
-            return checkTypes(subType.getParameterTypes(), superType.getParameterTypes(), checkStrategy);
+            return checkTypeArrays(subType.getParameterTypes(), superType.getParameterTypes(), checkStrategy, false);
         }
     }
 }

--- a/packages/typir/src/kinds/fixed-parameters-kind.ts
+++ b/packages/typir/src/kinds/fixed-parameters-kind.ts
@@ -184,6 +184,8 @@ export class FixedParameterKind implements Kind {
 
     // the order of parameters matters!
     createFixedParameterType(typeDetails: FixedParameterTypeDetails): FixedParameterType {
+        assertTrue(this.getFixedParameterType(typeDetails) === undefined);
+
         // create the class type
         const typeWithParameters = new FixedParameterType(this, this.calculateIdentifier(typeDetails), ...toArray(typeDetails.parameterTypes));
         this.typir.graph.addNode(typeWithParameters);

--- a/packages/typir/src/kinds/fixed-parameters-kind.ts
+++ b/packages/typir/src/kinds/fixed-parameters-kind.ts
@@ -55,8 +55,12 @@ export class FixedParameterType extends Type {
         return this.parameterValues.map(p => p.type);
     }
 
+    override getName(): string {
+        return `${this.kind.printSignature(this.kind.baseName, this.getParameterTypes(), ', ')}`;
+    }
+
     override getUserRepresentation(): string {
-        return this.kind.printSignature(this.kind.baseName, this.getParameterTypes());
+        return this.getName();
     }
 
     override analyzeTypeEqualityProblems(otherType: Type): TypirProblem[] {
@@ -188,11 +192,11 @@ export class FixedParameterKind implements Kind {
     }
 
     calculateIdentifier(typeDetails: FixedParameterTypeDetails): string {
-        return this.printSignature(this.baseName, toArray(typeDetails.parameterTypes)); // use the signature for a unique name
+        return this.printSignature(this.baseName, toArray(typeDetails.parameterTypes), ','); // use the signature for a unique name
     }
 
-    printSignature(baseName: string, parameterTypes: Type[]): string {
-        return `${baseName}<${parameterTypes.map(p => this.typir.printer.printType(p)).join(', ')}>`;
+    printSignature(baseName: string, parameterTypes: Type[], parameterSeparator: string): string {
+        return `${baseName}<${parameterTypes.map(p => p.getName()).join(parameterSeparator)}>`;
     }
 
 }

--- a/packages/typir/src/kinds/fixed-parameters-kind.ts
+++ b/packages/typir/src/kinds/fixed-parameters-kind.ts
@@ -74,6 +74,7 @@ export class FixedParameterType extends Type {
             }
         } else {
             return [<TypeEqualityProblem>{
+                $problem: TypeEqualityProblem,
                 type1: this,
                 type2: otherType,
                 subProblems: [createKindConflict(this, otherType)],
@@ -86,6 +87,7 @@ export class FixedParameterType extends Type {
             return this.analyzeSubTypeProblems(this, superType);
         } else {
             return [<SubTypeProblem>{
+                $problem: SubTypeProblem,
                 superType,
                 subType: this,
                 subProblems: [createKindConflict(this, superType)],
@@ -98,6 +100,7 @@ export class FixedParameterType extends Type {
             return this.analyzeSubTypeProblems(subType, this);
         } else {
             return [<SubTypeProblem>{
+                $problem: SubTypeProblem,
                 superType: this,
                 subType,
                 subProblems: [createKindConflict(subType, this)],

--- a/packages/typir/src/kinds/fixed-parameters-kind.ts
+++ b/packages/typir/src/kinds/fixed-parameters-kind.ts
@@ -4,17 +4,133 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { TypeEqualityProblem } from '../features/equality.js';
 import { SubTypeProblem } from '../features/subtype.js';
-import { TypeEdge } from '../graph/type-edge.js';
-import { Type } from '../graph/type-node.js';
+import { Type, isType } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { TypirProblem } from '../utils/utils-definitions.js';
-import { TypeCheckStrategy, checkTypes, checkValueForConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
-import { assertKind, assertTrue, toArray } from '../utils/utils.js';
+import { TypeCheckStrategy, checkTypes, checkValueForConflict, createKindConflict, createTypeCheckStrategy } from '../utils/utils-type-comparison.js';
+import { assertTrue, toArray } from '../utils/utils.js';
 import { Kind, isKind } from './kind.js';
 
+export class Parameter {
+    readonly name: string;
+    readonly index: number;
+
+    constructor(name: string, index: number) {
+        this.name = name;
+        this.index = index;
+    }
+}
+
+export class ParameterValue {
+    readonly parameter: Parameter;
+    readonly type: Type;
+
+    constructor(parameter: Parameter, type: Type) {
+        this.parameter = parameter;
+        this.type = type;
+    }
+}
+
+export class FixedParameterType extends Type {
+    override readonly kind: FixedParameterKind;
+    readonly parameterValues: ParameterValue[];
+
+    constructor(kind: FixedParameterKind, identifier: string, ...typeValues: Type[]) {
+        super(identifier);
+        this.kind = kind;
+
+        // set the parameter values
+        assertTrue(kind.parameters.length === typeValues.length);
+        for (let i = 0; i < typeValues.length; i++) {
+            this.parameterValues.push({
+                parameter: kind.parameters[i],
+                type: typeValues[i],
+            });
+        }
+    }
+
+    getParameterTypes(): Type[] {
+        return this.parameterValues.map(p => p.type);
+    }
+
+    override getUserRepresentation(): string {
+        return this.kind.printSignature(this.kind.baseName, this.getParameterTypes());
+    }
+
+    override analyzeTypeEqualityProblems(otherType: Type): TypirProblem[] {
+        if (isFixedParameterType(otherType)) {
+            // same name, e.g. both need to be Map, Set, Array, ...
+            const baseTypeCheck = checkValueForConflict(this.kind.baseName, otherType.kind.baseName, 'base type');
+            if (baseTypeCheck.length >= 1) {
+                // e.g. List<String> !== Set<String>
+                return baseTypeCheck;
+            } else {
+                // all parameter types must match, e.g. Set<String> !== Set<Boolean>
+                const conflicts: TypirProblem[] = [];
+                conflicts.push(...checkTypes(this.getParameterTypes(), otherType.getParameterTypes(), (t1, t2) => this.kind.typir.equality.getTypeEqualityProblem(t1, t2)));
+                return conflicts;
+            }
+        } else {
+            return [<TypeEqualityProblem>{
+                type1: this,
+                type2: otherType,
+                subProblems: [createKindConflict(this, otherType)],
+            }];
+        }
+    }
+
+    override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
+        if (isFixedParameterType(superType)) {
+            return this.analyzeSubTypeProblems(this, superType);
+        } else {
+            return [<SubTypeProblem>{
+                superType,
+                subType: this,
+                subProblems: [createKindConflict(this, superType)],
+            }];
+        }
+    }
+
+    override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
+        if (isFixedParameterType(subType)) {
+            return this.analyzeSubTypeProblems(subType, this);
+        } else {
+            return [<SubTypeProblem>{
+                superType: this,
+                subType,
+                subProblems: [createKindConflict(subType, this)],
+            }];
+        }
+    }
+
+    protected analyzeSubTypeProblems(subType: FixedParameterType, superType: FixedParameterType): TypirProblem[] {
+        // same name, e.g. both need to be Map, Set, Array, ...
+        const baseTypeCheck = checkValueForConflict(subType.kind.baseName, superType.kind.baseName, 'base type');
+        if (baseTypeCheck.length >= 1) {
+            // e.g. List<String> !== Set<String>
+            return baseTypeCheck;
+        } else {
+            // all parameter types must match, e.g. Set<String> !== Set<Boolean>
+            const checkStrategy = createTypeCheckStrategy(this.kind.options.parameterSubtypeCheckingStrategy, this.kind.typir);
+            return checkTypes(subType.getParameterTypes(), superType.getParameterTypes(), checkStrategy);
+        }
+    }
+}
+
+export function isFixedParameterType(type: unknown): type is FixedParameterType {
+    return isType(type) && isFixedParametersKind(type.kind);
+}
+
+
+
+export interface FixedParameterTypeDetails {
+    parameterTypes: Type | Type[]
+}
+
 export interface FixedParameterKindOptions {
-    subtypeParameterChecking: TypeCheckStrategy,
+    parameterSubtypeCheckingStrategy: TypeCheckStrategy,
 }
 
 export const FixedParameterKindName = 'FixedParameterKind';
@@ -27,85 +143,43 @@ export class FixedParameterKind implements Kind {
     readonly typir: Typir;
     readonly baseName: string;
     readonly options: FixedParameterKindOptions;
-    readonly parameterNames: string[];
+    readonly parameters: Parameter[]; // assumption: the parameters are in the correct order!
 
     constructor(typir: Typir, baseName: string, options?: Partial<FixedParameterKindOptions>, ...parameterNames: string[]) {
-        this.$name = `FixedParameterKind-${baseName}`;
+        this.$name = `${FixedParameterKindName}-${baseName}`;
         this.typir = typir;
         this.typir.registerKind(this);
         this.baseName = baseName;
         this.options = {
             // the default values:
-            subtypeParameterChecking: 'EQUAL_TYPE',
+            parameterSubtypeCheckingStrategy: 'EQUAL_TYPE',
             // the actually overriden values:
             ...options
         };
-        this.parameterNames = parameterNames;
+        this.parameters = parameterNames.map((name, index) => <Parameter>{ name, index });
 
         // check input
-        assertTrue(this.parameterNames.length >= 1);
+        assertTrue(this.parameters.length >= 1);
     }
 
     // the order of parameters matters!
-    createFixedParameterType(typeDetails: {
-        parameterTypes: Type | Type[]
-    }): Type {
-        const theParameterTypes = toArray(typeDetails.parameterTypes);
-
+    createFixedParameterType(typeDetails: FixedParameterTypeDetails): FixedParameterType {
         // create the class type
-        const typeWithParameters = new Type(this, this.printSignature(this.baseName, theParameterTypes)); // use the signature for a unique name
+        const typeWithParameters = new FixedParameterType(this, this.calculateIdentifier(typeDetails), ...toArray(typeDetails.parameterTypes));
         this.typir.graph.addNode(typeWithParameters);
-
-        // add the given types to the required fixed parameters
-        assertTrue(this.parameterNames.length === theParameterTypes.length);
-        for (let index = 0; index < this.parameterNames.length; index++) {
-            const edge = new TypeEdge(typeWithParameters, theParameterTypes[index], FIXED_PARAMETER_TYPE);
-            this.typir.graph.addEdge(edge);
-        }
 
         return typeWithParameters;
     }
 
-    getUserRepresentation(type: Type): string {
-        assertKind(type.kind, isFixedParametersKind);
-        return this.printSignature(this.baseName, this.getParameterTypes(type));
+    calculateIdentifier(typeDetails: FixedParameterTypeDetails): string {
+        return this.printSignature(this.baseName, toArray(typeDetails.parameterTypes)); // use the signature for a unique name
     }
-    protected printSignature(baseName: string, parameterTypes: Type[]): string {
+
+    printSignature(baseName: string, parameterTypes: Type[]): string {
         return `${baseName}<${parameterTypes.map(p => this.typir.printer.printType(p)).join(', ')}>`;
     }
 
-    analyzeSubTypeProblems(subType: Type, superType: Type): TypirProblem[] {
-        // same name, e.g. both need to be Map, Set, Array, ...
-        if (isFixedParametersKind(superType.kind) && isFixedParametersKind(subType.kind) && superType.kind.baseName === subType.kind.baseName) {
-            // all parameter types must match
-            const checkStrategy = createTypeCheckStrategy(this.options.subtypeParameterChecking, this.typir);
-            return checkTypes(subType.kind.getParameterTypes(subType), superType.kind.getParameterTypes(superType), checkStrategy);
-        }
-        return [<SubTypeProblem>{
-            superType,
-            subType,
-            subProblems: checkValueForConflict(superType.kind.$name, subType.kind.$name, 'kind'),
-        }];
-    }
-
-    analyzeTypeEqualityProblems(type1: Type, type2: Type): TypirProblem[] {
-        if (isFixedParametersKind(type1.kind) && isFixedParametersKind(type2.kind) && type1.kind.baseName === type2.kind.baseName) {
-            const conflicts: TypirProblem[] = [];
-            conflicts.push(...checkTypes(type1.kind.getParameterTypes(type1), type2.kind.getParameterTypes(type2), (t1, t2) => this.typir.equality.getTypeEqualityProblem(t1, t2)));
-            return conflicts;
-        }
-        throw new Error();
-    }
-
-    getParameterTypes(fixedParameterType: Type): Type[] {
-        assertKind(fixedParameterType.kind, isFixedParametersKind);
-        const result = fixedParameterType.getOutgoingEdges(FIXED_PARAMETER_TYPE).map(edge => edge.to);
-        assertTrue(result.length === this.parameterNames.length);
-        return result;
-    }
 }
-
-const FIXED_PARAMETER_TYPE = 'hasField';
 
 export function isFixedParametersKind(kind: unknown): kind is FixedParameterKind {
     return isKind(kind) && kind.$name.startsWith('FixedParameterKind-');

--- a/packages/typir/src/kinds/fixed-parameters-kind.ts
+++ b/packages/typir/src/kinds/fixed-parameters-kind.ts
@@ -165,6 +165,19 @@ export class FixedParameterKind implements Kind {
         assertTrue(this.parameters.length >= 1);
     }
 
+    getFixedParameterType(typeDetails: FixedParameterTypeDetails): FixedParameterType | undefined {
+        const key = this.calculateIdentifier(typeDetails);
+        return this.typir.graph.getType(key) as FixedParameterType;
+    }
+
+    getOrCreateFixedParameterType(typeDetails: FixedParameterTypeDetails): FixedParameterType {
+        const result = this.getFixedParameterType(typeDetails);
+        if (result) {
+            return result;
+        }
+        return this.createFixedParameterType(typeDetails);
+    }
+
     // the order of parameters matters!
     createFixedParameterType(typeDetails: FixedParameterTypeDetails): FixedParameterType {
         // create the class type

--- a/packages/typir/src/kinds/fixed-parameters-kind.ts
+++ b/packages/typir/src/kinds/fixed-parameters-kind.ts
@@ -35,7 +35,7 @@ export class ParameterValue {
 
 export class FixedParameterType extends Type {
     override readonly kind: FixedParameterKind;
-    readonly parameterValues: ParameterValue[];
+    readonly parameterValues: ParameterValue[] = [];
 
     constructor(kind: FixedParameterKind, identifier: string, ...typeValues: Type[]) {
         super(identifier);

--- a/packages/typir/src/kinds/function-kind.ts
+++ b/packages/typir/src/kinds/function-kind.ts
@@ -365,7 +365,7 @@ export class FunctionKind implements Kind {
     }
 
     getFunctionType(typeDetails: FunctionTypeDetails): FunctionType | undefined {
-        const key = this.printFunctionType(typeDetails);
+        const key = this.calculateIdentifier(typeDetails);
         return this.typir.graph.getType(key) as FunctionType;
     }
 
@@ -391,7 +391,7 @@ export class FunctionKind implements Kind {
         this.enforceName(functionName, this.options.enforceFunctionName);
 
         // create the function type
-        const functionType = new FunctionType(this, (this.calculateIdentifier(typeDetails)), typeDetails);
+        const functionType = new FunctionType(this, this.calculateIdentifier(typeDetails), typeDetails);
         this.typir.graph.addNode(functionType);
 
         // output parameter

--- a/packages/typir/src/kinds/function-kind.ts
+++ b/packages/typir/src/kinds/function-kind.ts
@@ -162,8 +162,8 @@ export interface FunctionKindOptions {
     /** Will be used only internally as prefix for the unique identifiers for function type names. */
     identifierPrefix: string,
     /** If a function has no output type (e.g. "void" functions), this type is returned during the type inference of calls to these functions.
-     * The default value "undefined" indicates to throw an error, i.e. type inference for calls of such functions are not allowed. */
-    typeToInferForCallsOfFunctionsWithoutOutput: TypeSelector | undefined;
+     * The default value "THROW_ERROR" indicates to throw an error, i.e. type inference for calls of such functions are not allowed. */
+    typeToInferForCallsOfFunctionsWithoutOutput: 'THROW_ERROR' | TypeSelector;
     subtypeParameterChecking: TypeCheckStrategy;
 }
 
@@ -266,7 +266,7 @@ export class FunctionKind implements Kind {
             enforceInputParameterNames: false,
             enforceOutputParameterName: false,
             identifierPrefix: 'function',
-            typeToInferForCallsOfFunctionsWithoutOutput: undefined,
+            typeToInferForCallsOfFunctionsWithoutOutput: 'THROW_ERROR',
             subtypeParameterChecking: 'SUB_TYPE',
             // the actually overriden values:
             ...options
@@ -402,7 +402,8 @@ export class FunctionKind implements Kind {
         // output parameter for function calls
         const outputTypeForFunctionCalls = functionType.getOutput()?.type ?? // by default, use the return type of the function ...
             // ... if this type is missing, use the specified type for this case in the options:
-            (this.options.typeToInferForCallsOfFunctionsWithoutOutput ? resolveTypeSelector(this.typir, this.options.typeToInferForCallsOfFunctionsWithoutOutput) : undefined);
+            // 'THROW_ERROR': an error will be thrown later, when this case actually occurs!
+            (this.options.typeToInferForCallsOfFunctionsWithoutOutput === 'THROW_ERROR' ? undefined : resolveTypeSelector(this.typir, this.options.typeToInferForCallsOfFunctionsWithoutOutput));
 
         // remember the new function for later in order to enable overloaded functions!
         const mapNameTypes = this.mapNameTypes;

--- a/packages/typir/src/kinds/function-kind.ts
+++ b/packages/typir/src/kinds/function-kind.ts
@@ -255,6 +255,7 @@ export class FunctionKind implements Kind {
      * - How to remove function types later? How to observe this case/event? How to remove their inference rules and validations?
      */
     protected readonly mapNameTypes: Map<string, OverloadedFunctionDetails> = new Map(); // function name => all overloaded functions with this name/key
+    // TODO try to replace this map with calculating the required identifier for the function
 
     constructor(typir: Typir, options?: Partial<FunctionKindOptions>) {
         this.$name = FunctionKindName;

--- a/packages/typir/src/kinds/function-kind.ts
+++ b/packages/typir/src/kinds/function-kind.ts
@@ -95,7 +95,7 @@ export class FunctionType extends Type {
 
     override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
         if (isFunctionType(superType)) {
-            this.analyzeSubTypeProblems(this, superType);
+            return this.analyzeSubTypeProblems(this, superType);
         }
         return [<SubTypeProblem>{
             superType,
@@ -106,7 +106,7 @@ export class FunctionType extends Type {
 
     override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
         if (isFunctionType(subType)) {
-            this.analyzeSubTypeProblems(subType, this);
+            return this.analyzeSubTypeProblems(subType, this);
         }
         return [<SubTypeProblem>{
             superType: this,

--- a/packages/typir/src/kinds/kind.ts
+++ b/packages/typir/src/kinds/kind.ts
@@ -4,8 +4,6 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { Type } from '../graph/type-node.js';
-import { TypirProblem } from '../utils/utils-definitions.js';
 
 /**
  * Typir provides a default set of Kinds, e.g. primitive types and class types.
@@ -13,14 +11,6 @@ import { TypirProblem } from '../utils/utils-definitions.js';
  */
 export interface Kind {
     readonly $name: string;
-
-    getUserRepresentation(type: Type): string;
-
-    /** If the kinds of super type and sub type are different, this function will be called for both kinds in order to check,
-     * whether at least one kinds reports a sub-type-relationship. */
-    analyzeSubTypeProblems(subType: Type, superType: Type): TypirProblem[];
-
-    analyzeTypeEqualityProblems(type1: Type, type2: Type): TypirProblem[];
 }
 
 export function isKind(kind: unknown): kind is Kind {

--- a/packages/typir/src/kinds/multiplicity-kind.ts
+++ b/packages/typir/src/kinds/multiplicity-kind.ts
@@ -10,6 +10,7 @@ import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { TypirProblem } from '../utils/utils-definitions.js';
 import { checkValueForConflict, createKindConflict } from '../utils/utils-type-comparison.js';
+import { assertTrue } from '../utils/utils.js';
 import { isKind, Kind } from './kind.js';
 
 export class MultiplicityType extends Type {
@@ -164,6 +165,7 @@ export class MultiplicityKind implements Kind {
 
     createMultiplicityType(typeDetails: MultiplicityTypeDetails): MultiplicityType {
         // check input
+        assertTrue(this.getMultiplicityType(typeDetails) === undefined);
         if (!this.checkBounds(typeDetails.lowerBound, typeDetails.upperBound)) {
             throw new Error();
         }

--- a/packages/typir/src/kinds/multiplicity-kind.ts
+++ b/packages/typir/src/kinds/multiplicity-kind.ts
@@ -56,25 +56,27 @@ export class MultiplicityType extends Type {
     override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
         if (isMultiplicityType(superType)) {
             return this.analyzeSubTypeProblems(this, superType);
+        } else {
+            return [<SubTypeProblem>{
+                $problem: SubTypeProblem,
+                superType,
+                subType: this,
+                subProblems: [createKindConflict(this, superType)],
+            }];
         }
-        return [<SubTypeProblem>{
-            $problem: SubTypeProblem,
-            superType,
-            subType: this,
-            subProblems: [createKindConflict(this, superType)],
-        }];
     }
 
     override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
         if (isMultiplicityType(subType)) {
             return this.analyzeSubTypeProblems(subType, this);
+        } else {
+            return [<SubTypeProblem>{
+                $problem: SubTypeProblem,
+                superType: this,
+                subType,
+                subProblems: [createKindConflict(subType, this)],
+            }];
         }
-        return [<SubTypeProblem>{
-            $problem: SubTypeProblem,
-            superType: this,
-            subType,
-            subProblems: [createKindConflict(subType, this)],
-        }];
     }
 
     protected analyzeSubTypeProblems(subType: MultiplicityType, superType: MultiplicityType): TypirProblem[] {

--- a/packages/typir/src/kinds/multiplicity-kind.ts
+++ b/packages/typir/src/kinds/multiplicity-kind.ts
@@ -145,7 +145,20 @@ export class MultiplicityKind implements Kind {
         };
     }
 
-    createMultiplicityForType(typeDetails: MultiplicityTypeDetails): MultiplicityType {
+    getMultiplicityType(typeDetails: MultiplicityTypeDetails): MultiplicityType | undefined {
+        const key = this.calculateIdentifier(typeDetails);
+        return this.typir.graph.getType(key) as MultiplicityType;
+    }
+
+    getOrCreateMultiplicityType(typeDetails: MultiplicityTypeDetails): MultiplicityType {
+        const result = this.getMultiplicityType(typeDetails);
+        if (result) {
+            return result;
+        }
+        return this.createMultiplicityType(typeDetails);
+    }
+
+    createMultiplicityType(typeDetails: MultiplicityTypeDetails): MultiplicityType {
         // check input
         if (!this.checkBounds(typeDetails.lowerBound, typeDetails.upperBound)) {
             throw new Error();

--- a/packages/typir/src/kinds/multiplicity-kind.ts
+++ b/packages/typir/src/kinds/multiplicity-kind.ts
@@ -45,6 +45,7 @@ export class MultiplicityType extends Type {
             return conflicts;
         } else {
             return [<TypeEqualityProblem>{
+                $problem: TypeEqualityProblem,
                 type1: this,
                 type2: otherType,
                 subProblems: [createKindConflict(otherType, this)],
@@ -57,6 +58,7 @@ export class MultiplicityType extends Type {
             return this.analyzeSubTypeProblems(this, superType);
         }
         return [<SubTypeProblem>{
+            $problem: SubTypeProblem,
             superType,
             subType: this,
             subProblems: [createKindConflict(this, superType)],
@@ -68,6 +70,7 @@ export class MultiplicityType extends Type {
             return this.analyzeSubTypeProblems(subType, this);
         }
         return [<SubTypeProblem>{
+            $problem: SubTypeProblem,
             superType: this,
             subType,
             subProblems: [createKindConflict(subType, this)],

--- a/packages/typir/src/kinds/multiplicity-kind.ts
+++ b/packages/typir/src/kinds/multiplicity-kind.ts
@@ -27,8 +27,12 @@ export class MultiplicityType extends Type {
         this.upperBound = upperBound;
     }
 
-    override getUserRepresentation(): string {
+    override getName(): string {
         return this.kind.printType(this.getConstrainedType(), this.getLowerBound(), this.getUpperBound());
+    }
+
+    override getUserRepresentation(): string {
+        return this.getName();
     }
 
     override analyzeTypeEqualityProblems(otherType: Type): TypirProblem[] {
@@ -188,7 +192,7 @@ export class MultiplicityKind implements Kind {
     }
 
     printType(constrainedType: Type, lowerBound: number, upperBound: number): string {
-        return `${this.typir.printer.printType(constrainedType)}${this.printRange(lowerBound, upperBound)}`;
+        return `${constrainedType.getName()}${this.printRange(lowerBound, upperBound)}`;
     }
     protected printRange(lowerBound: number, upperBound: number): string {
         if (lowerBound === upperBound || (lowerBound === 0 && upperBound === MULTIPLICITY_UNLIMITED)) {

--- a/packages/typir/src/kinds/multiplicity-kind.ts
+++ b/packages/typir/src/kinds/multiplicity-kind.ts
@@ -54,16 +54,7 @@ export class MultiplicityType extends Type {
 
     override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
         if (isMultiplicityType(superType)) {
-            const conflicts: TypirProblem[] = [];
-            // check the multiplicities
-            conflicts.push(...checkValueForConflict(this.getLowerBound(), superType.getLowerBound(), 'lower bound', this.kind.isBoundGreaterEquals));
-            conflicts.push(...checkValueForConflict(this.getUpperBound(), superType.getUpperBound(), 'upper bound', this.kind.isBoundGreaterEquals));
-            // check the constrained type
-            const constrainedTypeConflict = this.kind.typir.subtype.getSubTypeProblem(this.getConstrainedType(), superType.getConstrainedType());
-            if (constrainedTypeConflict !== undefined) {
-                conflicts.push(constrainedTypeConflict);
-            }
-            return conflicts;
+            return this.analyzeSubTypeProblems(this, superType);
         }
         return [<SubTypeProblem>{
             superType,
@@ -74,22 +65,26 @@ export class MultiplicityType extends Type {
 
     override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
         if (isMultiplicityType(subType)) {
-            const conflicts: TypirProblem[] = [];
-            // check the multiplicities
-            conflicts.push(...checkValueForConflict(subType.getLowerBound(), this.getLowerBound(), 'lower bound', this.kind.isBoundGreaterEquals));
-            conflicts.push(...checkValueForConflict(subType.getUpperBound(), this.getUpperBound(), 'upper bound', this.kind.isBoundGreaterEquals));
-            // check the constrained type
-            const constrainedTypeConflict = this.kind.typir.subtype.getSubTypeProblem(subType.getConstrainedType(), this.getConstrainedType());
-            if (constrainedTypeConflict !== undefined) {
-                conflicts.push(constrainedTypeConflict);
-            }
-            return conflicts;
+            return this.analyzeSubTypeProblems(subType, this);
         }
         return [<SubTypeProblem>{
             superType: this,
             subType,
             subProblems: [createKindConflict(subType, this)],
         }];
+    }
+
+    protected analyzeSubTypeProblems(subType: MultiplicityType, superType: MultiplicityType): TypirProblem[] {
+        const conflicts: TypirProblem[] = [];
+        // check the multiplicities
+        conflicts.push(...checkValueForConflict(subType.getLowerBound(), superType.getLowerBound(), 'lower bound', this.kind.isBoundGreaterEquals));
+        conflicts.push(...checkValueForConflict(subType.getUpperBound(), superType.getUpperBound(), 'upper bound', this.kind.isBoundGreaterEquals));
+        // check the constrained type
+        const constrainedTypeConflict = this.kind.typir.subtype.getSubTypeProblem(subType.getConstrainedType(), superType.getConstrainedType());
+        if (constrainedTypeConflict !== undefined) {
+            conflicts.push(constrainedTypeConflict);
+        }
+        return conflicts;
     }
 
     getConstrainedType(): Type {

--- a/packages/typir/src/kinds/primitive-kind.ts
+++ b/packages/typir/src/kinds/primitive-kind.ts
@@ -4,14 +4,74 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { TypeEqualityProblem } from '../features/equality.js';
 import { InferenceRuleNotApplicable } from '../features/inference.js';
 import { SubTypeProblem } from '../features/subtype.js';
-import { Type } from '../graph/type-node.js';
+import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { TypirProblem } from '../utils/utils-definitions.js';
-import { checkValueForConflict } from '../utils/utils-type-comparison.js';
-import { assertKind, toArray } from '../utils/utils.js';
-import { Kind, isKind } from './kind.js';
+import { checkValueForConflict, createKindConflict } from '../utils/utils-type-comparison.js';
+import { toArray } from '../utils/utils.js';
+import { isKind, Kind } from './kind.js';
+
+export class PrimitiveType extends Type {
+    override readonly kind: PrimitiveKind;
+
+    constructor(kind: PrimitiveKind, identifier: string) {
+        super(identifier);
+        this.kind = kind;
+    }
+
+    override getUserRepresentation(): string {
+        return this.identifier;
+    }
+
+    override analyzeTypeEqualityProblems(otherType: Type): TypirProblem[] {
+        if (isPrimitiveType(otherType)) {
+            return checkValueForConflict(this.identifier, otherType.identifier, 'name');
+        }
+        return [<TypeEqualityProblem>{
+            type1: this,
+            type2: otherType,
+            subProblems: [createKindConflict(otherType, this)],
+        }];
+    }
+
+    override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
+        if (isPrimitiveType(superType)) {
+            return this.analyzeTypeEqualityProblems(superType);
+        }
+        return [<SubTypeProblem>{
+            superType,
+            subType: this,
+            subProblems: [createKindConflict(this, superType)],
+        }];
+    }
+
+    override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
+        if (isPrimitiveType(subType)) {
+            return this.analyzeTypeEqualityProblems(subType);
+        }
+        return [<SubTypeProblem>{
+            superType: this,
+            subType,
+            subProblems: [createKindConflict(subType, this)],
+        }];
+    }
+
+}
+
+export function isPrimitiveType(type: unknown): type is PrimitiveType {
+    return isType(type) && isPrimitiveKind(type.kind);
+}
+
+
+
+export interface PrimitiveTypeDetails {
+    primitiveName: string;
+    /** In case of multiple inference rules, later rules are not evaluated anymore, if an earler rule already matched. */
+    inferenceRules?: InferPrimitiveType | InferPrimitiveType[];
+}
 
 export type InferPrimitiveType = (domainElement: unknown) => boolean;
 
@@ -22,19 +82,16 @@ export class PrimitiveKind implements Kind {
     readonly typir: Typir;
 
     constructor(typir: Typir) {
-        this.$name = 'PrimitiveKind';
+        this.$name = PrimitiveKindName;
         this.typir = typir;
         this.typir.registerKind(this);
     }
 
-    createPrimitiveType(typeDetails: {
-        primitiveName: string,
-        /** In case of multiple inference rules, later rules are not evaluated anymore, if an earler rule already matched. */
-        inferenceRules?: InferPrimitiveType | InferPrimitiveType[]
-    }): Type {
+    createPrimitiveType(typeDetails: PrimitiveTypeDetails): PrimitiveType {
         // create the primitive type
-        const primitiveType = new Type(this, typeDetails.primitiveName);
+        const primitiveType = new PrimitiveType(this, this.calculateIdentifier(typeDetails));
         this.typir.graph.addNode(primitiveType);
+
         // register all inference rules for primitives within a single generic inference rule (in order to keep the number of "global" inference rules small)
         const rules = toArray(typeDetails.inferenceRules);
         if (rules.length >= 1) {
@@ -47,30 +104,12 @@ export class PrimitiveKind implements Kind {
                 return InferenceRuleNotApplicable;
             });
         }
+
         return primitiveType;
     }
 
-    getUserRepresentation(type: Type): string {
-        assertKind(type.kind, isPrimitiveKind);
-        return type.name;
-    }
-
-    analyzeSubTypeProblems(subType: Type, superType: Type): TypirProblem[] {
-        if (isPrimitiveKind(superType.kind) && isPrimitiveKind(subType.kind)) {
-            return this.analyzeTypeEqualityProblems(superType, subType);
-        }
-        return [<SubTypeProblem>{
-            superType,
-            subType,
-            subProblems: checkValueForConflict(superType.kind.$name, subType.kind.$name, 'kind'),
-        }];
-    }
-
-    analyzeTypeEqualityProblems(type1: Type, type2: Type): TypirProblem[] {
-        if (isPrimitiveKind(type1.kind) && isPrimitiveKind(type2.kind)) {
-            return checkValueForConflict(type1.name, type2.name, 'name');
-        }
-        throw new Error();
+    calculateIdentifier(typeDetails: PrimitiveTypeDetails): string {
+        return typeDetails.primitiveName;
     }
 }
 

--- a/packages/typir/src/kinds/primitive-kind.ts
+++ b/packages/typir/src/kinds/primitive-kind.ts
@@ -31,6 +31,7 @@ export class PrimitiveType extends Type {
             return checkValueForConflict(this.identifier, otherType.identifier, 'name');
         }
         return [<TypeEqualityProblem>{
+            $problem: TypeEqualityProblem,
             type1: this,
             type2: otherType,
             subProblems: [createKindConflict(otherType, this)],
@@ -42,6 +43,7 @@ export class PrimitiveType extends Type {
             return this.analyzeTypeEqualityProblems(superType);
         }
         return [<SubTypeProblem>{
+            $problem: SubTypeProblem,
             superType,
             subType: this,
             subProblems: [createKindConflict(this, superType)],
@@ -53,6 +55,7 @@ export class PrimitiveType extends Type {
             return this.analyzeTypeEqualityProblems(subType);
         }
         return [<SubTypeProblem>{
+            $problem: SubTypeProblem,
             superType: this,
             subType,
             subProblems: [createKindConflict(subType, this)],

--- a/packages/typir/src/kinds/primitive-kind.ts
+++ b/packages/typir/src/kinds/primitive-kind.ts
@@ -41,7 +41,7 @@ export class PrimitiveType extends Type {
 
     override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
         if (isPrimitiveType(superType)) {
-            return this.analyzeTypeEqualityProblems(superType);
+            return this.analyzeSubTypeProblems(this, superType);
         } else {
             return [<SubTypeProblem>{
                 $problem: SubTypeProblem,
@@ -54,7 +54,7 @@ export class PrimitiveType extends Type {
 
     override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
         if (isPrimitiveType(subType)) {
-            return this.analyzeTypeEqualityProblems(subType);
+            return this.analyzeSubTypeProblems(subType, this);
         } else {
             return [<SubTypeProblem>{
                 $problem: SubTypeProblem,
@@ -63,6 +63,10 @@ export class PrimitiveType extends Type {
                 subProblems: [createKindConflict(subType, this)],
             }];
         }
+    }
+
+    protected analyzeSubTypeProblems(subType: PrimitiveType, superType: PrimitiveType): TypirProblem[] {
+        return subType.analyzeTypeEqualityProblems(superType);
     }
 
 }
@@ -91,6 +95,19 @@ export class PrimitiveKind implements Kind {
         this.$name = PrimitiveKindName;
         this.typir = typir;
         this.typir.registerKind(this);
+    }
+
+    getPrimitiveType(typeDetails: PrimitiveTypeDetails): PrimitiveType | undefined {
+        const key = this.calculateIdentifier(typeDetails);
+        return this.typir.graph.getType(key) as PrimitiveType;
+    }
+
+    getOrCreatePrimitiveType(typeDetails: PrimitiveTypeDetails): PrimitiveType {
+        const result = this.getPrimitiveType(typeDetails);
+        if (result) {
+            return result;
+        }
+        return this.createPrimitiveType(typeDetails);
     }
 
     createPrimitiveType(typeDetails: PrimitiveTypeDetails): PrimitiveType {

--- a/packages/typir/src/kinds/primitive-kind.ts
+++ b/packages/typir/src/kinds/primitive-kind.ts
@@ -11,7 +11,7 @@ import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { TypirProblem } from '../utils/utils-definitions.js';
 import { checkValueForConflict, createKindConflict } from '../utils/utils-type-comparison.js';
-import { toArray } from '../utils/utils.js';
+import { assertTrue, toArray } from '../utils/utils.js';
 import { isKind, Kind } from './kind.js';
 
 export class PrimitiveType extends Type {
@@ -115,6 +115,8 @@ export class PrimitiveKind implements Kind {
     }
 
     createPrimitiveType(typeDetails: PrimitiveTypeDetails): PrimitiveType {
+        assertTrue(this.getPrimitiveType(typeDetails) === undefined);
+
         // create the primitive type
         const primitiveType = new PrimitiveType(this, this.calculateIdentifier(typeDetails));
         this.typir.graph.addNode(primitiveType);

--- a/packages/typir/src/kinds/primitive-kind.ts
+++ b/packages/typir/src/kinds/primitive-kind.ts
@@ -22,6 +22,10 @@ export class PrimitiveType extends Type {
         this.kind = kind;
     }
 
+    override getName(): string {
+        return this.identifier;
+    }
+
     override getUserRepresentation(): string {
         return this.identifier;
     }

--- a/packages/typir/src/kinds/primitive-kind.ts
+++ b/packages/typir/src/kinds/primitive-kind.ts
@@ -29,37 +29,40 @@ export class PrimitiveType extends Type {
     override analyzeTypeEqualityProblems(otherType: Type): TypirProblem[] {
         if (isPrimitiveType(otherType)) {
             return checkValueForConflict(this.identifier, otherType.identifier, 'name');
+        } else {
+            return [<TypeEqualityProblem>{
+                $problem: TypeEqualityProblem,
+                type1: this,
+                type2: otherType,
+                subProblems: [createKindConflict(otherType, this)],
+            }];
         }
-        return [<TypeEqualityProblem>{
-            $problem: TypeEqualityProblem,
-            type1: this,
-            type2: otherType,
-            subProblems: [createKindConflict(otherType, this)],
-        }];
     }
 
     override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
         if (isPrimitiveType(superType)) {
             return this.analyzeTypeEqualityProblems(superType);
+        } else {
+            return [<SubTypeProblem>{
+                $problem: SubTypeProblem,
+                superType,
+                subType: this,
+                subProblems: [createKindConflict(this, superType)],
+            }];
         }
-        return [<SubTypeProblem>{
-            $problem: SubTypeProblem,
-            superType,
-            subType: this,
-            subProblems: [createKindConflict(this, superType)],
-        }];
     }
 
     override analyzeIsSuperTypeOf(subType: Type): TypirProblem[] {
         if (isPrimitiveType(subType)) {
             return this.analyzeTypeEqualityProblems(subType);
+        } else {
+            return [<SubTypeProblem>{
+                $problem: SubTypeProblem,
+                superType: this,
+                subType,
+                subProblems: [createKindConflict(subType, this)],
+            }];
         }
-        return [<SubTypeProblem>{
-            $problem: SubTypeProblem,
-            superType: this,
-            subType,
-            subProblems: [createKindConflict(subType, this)],
-        }];
     }
 
 }

--- a/packages/typir/src/kinds/top-kind.ts
+++ b/packages/typir/src/kinds/top-kind.ts
@@ -97,6 +97,19 @@ export class TopKind implements Kind {
         };
     }
 
+    getTopType(typeDetails: TopTypeDetails): TopType | undefined {
+        const key = this.calculateIdentifier(typeDetails);
+        return this.typir.graph.getType(key) as TopType;
+    }
+
+    getOrCreateTopType(typeDetails: TopTypeDetails): TopType {
+        const result = this.getTopType(typeDetails);
+        if (result) {
+            return result;
+        }
+        return this.createTopType(typeDetails);
+    }
+
     createTopType(typeDetails: TopTypeDetails): TopType {
         // create the top type (singleton)
         if (this.instance) {

--- a/packages/typir/src/kinds/top-kind.ts
+++ b/packages/typir/src/kinds/top-kind.ts
@@ -29,26 +29,28 @@ export class TopType extends Type {
     override analyzeTypeEqualityProblems(otherType: Type): TypirProblem[] {
         if (isTopType(otherType)) {
             return [];
+        } else {
+            return [<TypeEqualityProblem>{
+                $problem: TypeEqualityProblem,
+                type1: this,
+                type2: otherType,
+                subProblems: [createKindConflict(otherType, this)],
+            }];
         }
-        return [<TypeEqualityProblem>{
-            $problem: TypeEqualityProblem,
-            type1: this,
-            type2: otherType,
-            subProblems: [createKindConflict(otherType, this)],
-        }];
     }
 
     override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {
         if (isTopType(superType)) {
             // special case by definition: TopType is sub-type of TopType
             return [];
+        } else {
+            return [<SubTypeProblem>{
+                $problem: SubTypeProblem,
+                superType,
+                subType: this,
+                subProblems: [createKindConflict(superType, this)],
+            }];
         }
-        return [<SubTypeProblem>{
-            $problem: SubTypeProblem,
-            superType,
-            subType: this,
-            subProblems: [createKindConflict(superType, this)],
-        }];
     }
 
     override analyzeIsSuperTypeOf(_subType: Type): TypirProblem[] {

--- a/packages/typir/src/kinds/top-kind.ts
+++ b/packages/typir/src/kinds/top-kind.ts
@@ -22,6 +22,10 @@ export class TopType extends Type {
         this.kind = kind;
     }
 
+    override getName(): string {
+        return this.identifier;
+    }
+
     override getUserRepresentation(): string {
         return this.identifier;
     }

--- a/packages/typir/src/kinds/top-kind.ts
+++ b/packages/typir/src/kinds/top-kind.ts
@@ -11,7 +11,7 @@ import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { TypirProblem } from '../utils/utils-definitions.js';
 import { createKindConflict } from '../utils/utils-type-comparison.js';
-import { toArray } from '../utils/utils.js';
+import { assertTrue, toArray } from '../utils/utils.js';
 import { isKind, Kind } from './kind.js';
 
 export class TopType extends Type {
@@ -115,6 +115,8 @@ export class TopKind implements Kind {
     }
 
     createTopType(typeDetails: TopTypeDetails): TopType {
+        assertTrue(this.getTopType(typeDetails) === undefined);
+
         // create the top type (singleton)
         if (this.instance) {
             // note, that the given inference rules are ignored in this case!

--- a/packages/typir/src/kinds/top-kind.ts
+++ b/packages/typir/src/kinds/top-kind.ts
@@ -31,6 +31,7 @@ export class TopType extends Type {
             return [];
         }
         return [<TypeEqualityProblem>{
+            $problem: TypeEqualityProblem,
             type1: this,
             type2: otherType,
             subProblems: [createKindConflict(otherType, this)],
@@ -43,6 +44,7 @@ export class TopType extends Type {
             return [];
         }
         return [<SubTypeProblem>{
+            $problem: SubTypeProblem,
             superType,
             subType: this,
             subProblems: [createKindConflict(superType, this)],

--- a/packages/typir/src/kinds/top-kind.ts
+++ b/packages/typir/src/kinds/top-kind.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { TypeEqualityProblem } from '../features/equality.js';
 import { InferenceRuleNotApplicable } from '../features/inference.js';
 import { SubTypeProblem } from '../features/subtype.js';
 import { isType, Type } from '../graph/type-node.js';
@@ -29,7 +30,11 @@ export class TopType extends Type {
         if (isTopType(otherType)) {
             return [];
         }
-        throw new Error();
+        return [<TypeEqualityProblem>{
+            type1: this,
+            type2: otherType,
+            subProblems: [createKindConflict(otherType, this)],
+        }];
     }
 
     override analyzeIsSubTypeOf(superType: Type): TypirProblem[] {

--- a/packages/typir/src/typir.ts
+++ b/packages/typir/src/typir.ts
@@ -35,11 +35,6 @@ import { Kind } from './kinds/kind.js';
  *     - Cycles at instances/objects: Parent used as Child?!
  */
 
-/** TODO missing things
- * - support dedicated inference rules for all kinds
- * - separate kinds for bottom and top types!
- */
-
 export class Typir {
     // store types and kinds
     graph: TypeGraph = new TypeGraph();

--- a/packages/typir/src/utils/utils-definitions.ts
+++ b/packages/typir/src/utils/utils-definitions.ts
@@ -23,6 +23,9 @@ export type NameTypePair = {
     name: string;
     type: Type;
 }
+export function isNameTypePair(type: unknown): type is NameTypePair {
+    return typeof type === 'object' && type !== null && typeof (type as NameTypePair).name === 'string' && isType((type as NameTypePair).type);
+}
 
 // TODO this is a WIP sketch for managing the use of Types in properties/details of other Types (e.g. Types of fields of class Types)
 export interface TypeReference<T extends Type = Type> {

--- a/packages/typir/src/utils/utils-definitions.ts
+++ b/packages/typir/src/utils/utils-definitions.ts
@@ -7,8 +7,10 @@
 import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 
-// TODO besser durch implements Interface lösen, weil das einfacher zu erweitern ist!!
-// export type TypirProblem = ValueConflict | IndexedTypeConflict | AssignabilityProblem | SubTypeProblem | TypeEqualityProblem | InferenceProblem | ValidationProblem;
+/**
+ * Common interface of all problems/errors/messages which should be shown to users of DSLs which are type-checked with Typir.
+ * This approach makes it easier to introduce additional errors by users of Typir, compared to a union type, e.g. export type TypirProblem = ValueConflict | IndexedTypeConflict | ...
+ */
 export interface TypirProblem {
     readonly $problem: string;
 }

--- a/packages/typir/src/utils/utils-definitions.ts
+++ b/packages/typir/src/utils/utils-definitions.ts
@@ -14,7 +14,7 @@ import { Typir } from '../typir.js';
 export interface TypirProblem {
     readonly $problem: string;
 }
-export function isConcreteTypirProblem(problem: unknown, $problem: string): problem is TypirProblem {
+export function isSpecificTypirProblem(problem: unknown, $problem: string): problem is TypirProblem {
     return typeof problem === 'object' && problem !== null && ((problem as TypirProblem).$problem === $problem);
 }
 

--- a/packages/typir/src/utils/utils-definitions.ts
+++ b/packages/typir/src/utils/utils-definitions.ts
@@ -4,17 +4,17 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { AssignabilityProblem } from '../features/assignability.js';
-import { TypeEqualityProblem } from '../features/equality.js';
-import { InferenceProblem } from '../features/inference.js';
-import { SubTypeProblem } from '../features/subtype.js';
-import { ValidationProblem } from '../features/validation.js';
 import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
-import { ValueConflict, IndexedTypeConflict } from './utils-type-comparison.js';
 
 // TODO besser durch implements Interface lösen, weil das einfacher zu erweitern ist!!
-export type TypirProblem = ValueConflict | IndexedTypeConflict | AssignabilityProblem | SubTypeProblem | TypeEqualityProblem | InferenceProblem | ValidationProblem;
+// export type TypirProblem = ValueConflict | IndexedTypeConflict | AssignabilityProblem | SubTypeProblem | TypeEqualityProblem | InferenceProblem | ValidationProblem;
+export interface TypirProblem {
+    readonly $problem: string;
+}
+export function isConcreteTypirProblem(problem: unknown, $problem: string): problem is TypirProblem {
+    return typeof problem === 'object' && problem !== null && ((problem as TypirProblem).$problem === $problem);
+}
 
 export type Types = Type | Type[];
 export type Names = string | string[];

--- a/packages/typir/src/utils/utils-definitions.ts
+++ b/packages/typir/src/utils/utils-definitions.ts
@@ -13,6 +13,7 @@ import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { ValueConflict, IndexedTypeConflict } from './utils-type-comparison.js';
 
+// TODO besser durch implements Interface lösen, weil das einfacher zu erweitern ist!!
 export type TypirProblem = ValueConflict | IndexedTypeConflict | AssignabilityProblem | SubTypeProblem | TypeEqualityProblem | InferenceProblem | ValidationProblem;
 
 export type Types = Type | Type[];

--- a/packages/typir/src/utils/utils-type-comparison.ts
+++ b/packages/typir/src/utils/utils-type-comparison.ts
@@ -9,7 +9,7 @@ import { isType, Type } from '../graph/type-node.js';
 import { Kind } from '../kinds/kind.js';
 import { Typir } from '../typir.js';
 import { assertTrue } from '../utils/utils.js';
-import { isConcreteTypirProblem, isNameTypePair, NameTypePair, TypirProblem } from './utils-definitions.js';
+import { isSpecificTypirProblem, isNameTypePair, NameTypePair, TypirProblem } from './utils-definitions.js';
 import { InferenceProblem } from '../features/inference.js';
 
 export type TypeCheckStrategy =
@@ -44,7 +44,7 @@ export interface ValueConflict extends TypirProblem {
 }
 export const ValueConflict = 'ValueConflict';
 export function isValueConflict(problem: unknown): problem is ValueConflict {
-    return isConcreteTypirProblem(problem, ValueConflict);
+    return isSpecificTypirProblem(problem, ValueConflict);
 }
 
 export function checkValueForConflict<T>(first: T, second: T, location: string,
@@ -88,7 +88,7 @@ export interface IndexedTypeConflict extends TypirProblem {
 }
 export const IndexedTypeConflict = 'IndexedTypeConflict';
 export function isIndexedTypeConflict(problem: unknown): problem is IndexedTypeConflict {
-    return isConcreteTypirProblem(problem, IndexedTypeConflict);
+    return isSpecificTypirProblem(problem, IndexedTypeConflict);
 }
 
 export type TypeToCheck = Type | NameTypePair | undefined | InferenceProblem[];

--- a/packages/typir/src/utils/utils-type-comparison.ts
+++ b/packages/typir/src/utils/utils-type-comparison.ts
@@ -25,7 +25,7 @@ export function createTypeCheckStrategy(strategy: TypeCheckStrategy, typir: Typi
                 .bind(typir.equality);
         case 'SUB_TYPE':
             return typir.subtype.getSubTypeProblem // t1 === sub, t2 === super
-                .bind(typir.equality);
+                .bind(typir.subtype);
             // .bind(...) is required to have the correct value for 'this' inside the referenced function/method!
             // see https://stackoverflow.com/questions/20279484/how-to-access-the-correct-this-inside-a-callback
         default:

--- a/packages/typir/src/utils/utils-type-comparison.ts
+++ b/packages/typir/src/utils/utils-type-comparison.ts
@@ -5,10 +5,11 @@
  ******************************************************************************/
 
 import { assertUnreachable } from 'langium';
-import { Type } from '../graph/type-node.js';
+import { isType, Type } from '../graph/type-node.js';
 import { Typir } from '../typir.js';
 import { assertTrue } from '../utils/utils.js';
 import { NameTypePair, TypirProblem } from './utils-definitions.js';
+import { Kind } from '../kinds/kind.js';
 
 export type TypeCheckStrategy =
     'EQUAL_TYPE' | // the most strict checking
@@ -54,6 +55,20 @@ export function checkValueForConflict<T>(first: T, second: T, location: string,
         });
     }
     return conflicts;
+}
+
+export function createKindConflict(first: Type | Kind, second: Type | Kind): ValueConflict {
+    if (isType(first)) {
+        first = first.kind;
+    }
+    if (isType(second)) {
+        second = second.kind;
+    }
+    return {
+        firstValue: first.$name,
+        secondValue: second.$name,
+        location: 'kind',
+    };
 }
 
 export interface IndexedTypeConflict {

--- a/packages/typir/src/utils/utils.ts
+++ b/packages/typir/src/utils/utils.ts
@@ -4,6 +4,7 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { Type } from '../graph/type-node.js';
 import { Kind } from '../kinds/kind.js';
 
 export function assertTrue(condition: boolean, msg?: string): asserts condition {
@@ -31,5 +32,13 @@ export function assertKind<T extends Kind>(kind: unknown, check: (kind: unknown)
         // this is the expected case
     } else {
         throw new Error(msg ?? `'${kind}' has another kind`);
+    }
+}
+
+export function assertType<T extends Type>(type: unknown, check: (type: unknown) => type is T, msg?: string): asserts type is T {
+    if (check(type)) {
+        // this is the expected case
+    } else {
+        throw new Error(msg ?? `'${type}' has another type`);
     }
 }

--- a/packages/typir/test/type-definitions.test.ts
+++ b/packages/typir/test/type-definitions.test.ts
@@ -34,7 +34,7 @@ describe('Tests for Typir', () => {
         const typeBoolean = primitiveKind.createPrimitiveType({ primitiveName: 'Boolean' });
 
         // create class type Person with 1 firstName and 1..2 lastNames and a age properties
-        const typeOneOrTwoStrings = multiplicityKind.createMultiplicityForType({ constrainedType: typeString, lowerBound: 1, upperBound: 2 });
+        const typeOneOrTwoStrings = multiplicityKind.createMultiplicityType({ constrainedType: typeString, lowerBound: 1, upperBound: 2 });
         const typePerson = classKind.createClassType({
             className: 'Person',
             fields: [

--- a/packages/typir/test/type-definitions.test.ts
+++ b/packages/typir/test/type-definitions.test.ts
@@ -87,7 +87,7 @@ describe('Tests for Typir', () => {
         // it is possible to define multiple sources and/or targets at the same time:
         typir.conversion.markAsConvertible([typeInt, typeInt], [typeString, typeString, typeString], 'EXPLICIT');
         // single relationships are possible as well
-        typir.conversion.markAsConvertible(typeInt, typeString, 'IMPLICIT');
+        typir.conversion.markAsConvertible(typeInt, typeString, 'IMPLICIT_EXPLICIT');
 
         // is assignable?
         // primitives

--- a/packages/typir/test/type-definitions.test.ts
+++ b/packages/typir/test/type-definitions.test.ts
@@ -23,8 +23,8 @@ describe('Tests for Typir', () => {
         const primitiveKind = new PrimitiveKind(typir);
         const multiplicityKind = new MultiplicityKind(typir, { symbolForUnlimited: '*' });
         const classKind = new ClassKind(typir, { typing: 'Structural', maximumNumberOfSuperClasses: 1, subtypeFieldChecking: 'SUB_TYPE' });
-        const listKind = new FixedParameterKind(typir, 'List', { subtypeParameterChecking: 'EQUAL_TYPE' }, 'entry');
-        const mapKind = new FixedParameterKind(typir, 'Map', { subtypeParameterChecking: 'EQUAL_TYPE' }, 'key', 'value');
+        const listKind = new FixedParameterKind(typir, 'List', { parameterSubtypeCheckingStrategy: 'EQUAL_TYPE' }, 'entry');
+        const mapKind = new FixedParameterKind(typir, 'Map', { parameterSubtypeCheckingStrategy: 'EQUAL_TYPE' }, 'key', 'value');
         const functionKind = new FunctionKind(typir);
 
         // create some primitive types


### PR DESCRIPTION
This PR includes several issues we talked about during our last meetings.
* introduced PrimitiveType, ClassType, ... which extend Type
* introduced concrete types for edges and made TypeEdge abstract
* fixed bugs
* reduced the role of PrimitiveKind, ClassKind, ... accordingly
* `TypirProblem` is an interface to extend now instead of a type union in order to enable additional problems by users
* conversion: added structures to deal with transitivity and cycles, actual implementations of the algorithms are still missing (and will be added in another PR)
* first support for bottom types
* improved validation API
* introduced type.getName() to have a short string to show to users
* improved some details for FunctionTypes
* unified and extended logic to compare types with each other
* enforce uniqueness of new types, fixed calculation of uniqueness of functions
* refactorings, simplified code, comments

For the review, it might be easier to check the single commits.