### PR TITLE
Small fixes for lox example

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,7 +28,8 @@
             ],
             "sourceMaps": true,
             "outFiles": [
-              "${workspaceFolder}/examples/lox/out/**/*.js"
+              "${workspaceFolder}/examples/lox/out/**/*.js",
+              "${workspaceFolder}/examples/lox/node_modules/langium/**/*.js"
             ]
         },
         {

--- a/examples/lox/package.json
+++ b/examples/lox/package.json
@@ -75,6 +75,6 @@
     ],
     "main": "./out/extension/main.cjs",
     "bin": {
-        "ox-cli": "out/cli/main.js"
+        "lox-cli": "out/cli/main.js"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
                 "vscode-languageserver": "~9.0.1"
             },
             "bin": {
-                "ox-cli": "out/cli/main.js"
+                "lox-cli": "out/cli/main.js"
             },
             "devDependencies": {
                 "@types/vscode": "~1.94.0",


### PR DESCRIPTION
Investigating the lox example I recognised these small things. The ox-cli -> lox-cli seems to be a typo to me. The addition to launch.json is inspired by https://github.com/eclipse-langium/langium/discussions/410 and parallel to the config of ox.