### PR TITLE
Update Langium to v3.3

### DIFF
--- a/examples/lox/package.json
+++ b/examples/lox/package.json
@@ -29,14 +29,14 @@
     },
     "dependencies": {
         "commander": "~12.1.0",
-        "langium": "~3.2.0",
+        "langium": "~3.3.0",
         "typir-langium": "~0.0.2",
         "vscode-languageclient": "~9.0.1",
         "vscode-languageserver": "~9.0.1"
     },
     "devDependencies": {
         "@types/vscode": "~1.94.0",
-        "langium-cli": "~3.2.0"
+        "langium-cli": "~3.3.0"
     },
     "files": [
         "bin",

--- a/examples/ox/package.json
+++ b/examples/ox/package.json
@@ -29,14 +29,14 @@
     },
     "dependencies": {
         "commander": "~12.1.0",
-        "langium": "~3.2.0",
+        "langium": "~3.3.0",
         "typir-langium": "~0.0.2",
         "vscode-languageclient": "~9.0.1",
         "vscode-languageserver": "~9.0.1"
     },
     "devDependencies": {
         "@types/vscode": "~1.94.0",
-        "langium-cli": "~3.2.0"
+        "langium-cli": "~3.3.0"
     },
     "files": [
         "bin",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1507,10 +1507,11 @@
             }
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -2562,9 +2563,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.7",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
-            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
+            "version": "3.3.8",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+            "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
             "dev": true,
             "funding": [
                 {
@@ -2572,6 +2573,7 @@
                     "url": "https://github.com/sponsors/ai"
                 }
             ],
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
             "license": "MIT",
             "dependencies": {
                 "commander": "~12.1.0",
-                "langium": "~3.2.0",
+                "langium": "~3.3.0",
                 "typir-langium": "~0.0.2",
                 "vscode-languageclient": "~9.0.1",
                 "vscode-languageserver": "~9.0.1"
@@ -50,7 +50,7 @@
             },
             "devDependencies": {
                 "@types/vscode": "~1.94.0",
-                "langium-cli": "~3.2.0"
+                "langium-cli": "~3.3.0"
             },
             "engines": {
                 "vscode": "^1.67.0"
@@ -70,7 +70,7 @@
             "license": "MIT",
             "dependencies": {
                 "commander": "~12.1.0",
-                "langium": "~3.2.0",
+                "langium": "~3.3.0",
                 "typir-langium": "~0.0.2",
                 "vscode-languageclient": "~9.0.1",
                 "vscode-languageserver": "~9.0.1"
@@ -80,7 +80,7 @@
             },
             "devDependencies": {
                 "@types/vscode": "~1.94.0",
-                "langium-cli": "~3.2.0"
+                "langium-cli": "~3.3.0"
             },
             "engines": {
                 "vscode": "^1.67.0"
@@ -2381,9 +2381,10 @@
             }
         },
         "node_modules/langium": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/langium/-/langium-3.2.0.tgz",
-            "integrity": "sha512-HxAPgCVC7X+dCN99QKlZMEoaLW4s/mt0IImYrP6ooEBOMh8lJYdFNNSpJ5NIOE+WFwQd3xa2phTJDmJhOWVR7A==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/langium/-/langium-3.3.0.tgz",
+            "integrity": "sha512-y1n1MxeHtXvE0Ksi/HjLCvesHm3/Vr0pyyuA1fn+vmGSYR81NkxnC3bU4kd2o0CrZaz8xekz9rhm+lGfRgNFzw==",
+            "license": "MIT",
             "dependencies": {
                 "chevrotain": "~11.0.3",
                 "chevrotain-allstar": "~0.3.0",
@@ -2396,17 +2397,18 @@
             }
         },
         "node_modules/langium-cli": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-3.2.0.tgz",
-            "integrity": "sha512-4JWeCMuTHyFO+GCnOVT8+jygdob4KnU0uh/26cMxgZ1FlenAk8zrOnrXbuUzIm0FAIetCqrR6GUXqeko+Vg5og==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/langium-cli/-/langium-cli-3.3.0.tgz",
+            "integrity": "sha512-QWvlOYdLbso8/lv6Ma+SBtvMN9k70JrplLx6VSIcV7gJNDTXeS+tjwC/f6T0aco1fg8uLL8GiAcaMovd1FnneA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "chalk": "~5.3.0",
                 "commander": "~11.0.0",
                 "fs-extra": "~11.1.1",
                 "jsonschema": "~1.4.1",
-                "langium": "~3.2.0",
-                "langium-railroad": "~3.2.0",
+                "langium": "~3.3.0",
+                "langium-railroad": "~3.3.0",
                 "lodash": "~4.17.21"
             },
             "bin": {
@@ -2431,12 +2433,13 @@
             }
         },
         "node_modules/langium-railroad": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-3.2.0.tgz",
-            "integrity": "sha512-8wJqRid1udSH9PKo8AkRrJCUNHQ6Xu9tGi+//bLdHGDdlK9gpps1AwO71ufE864/so77K4ZmqBuLnBnxPcGs/Q==",
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/langium-railroad/-/langium-railroad-3.3.0.tgz",
+            "integrity": "sha512-x56CU0KnLoqYLkHEPDJjFoekFoCVbbZbmHduldiXjKD8owt6t5aqgWfg31OeMeR+7XgONZTtmsO76yl6GvEkzQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "langium": "~3.2.0",
+                "langium": "~3.3.0",
                 "railroad-diagrams": "~1.0.0"
             }
         },
@@ -2795,7 +2798,8 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
             "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-            "dev": true
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/rechoir": {
             "version": "0.6.2",
@@ -4079,7 +4083,7 @@
             "version": "0.0.2",
             "license": "MIT",
             "dependencies": {
-                "langium": "~3.2.0",
+                "langium": "~3.3.0",
                 "typir": "~0.0.2"
             },
             "engines": {

--- a/packages/typir-langium/package.json
+++ b/packages/typir-langium/package.json
@@ -48,7 +48,7 @@
   },
   "bugs": "https://github.com/TypeFox/typir/issues",
   "dependencies": {
-    "langium": "~3.2.0",
+    "langium": "~3.3.0",
     "typir": "~0.0.2"
   }
 }

--- a/packages/typir-langium/src/features/langium-type-creator.ts
+++ b/packages/typir-langium/src/features/langium-type-creator.ts
@@ -18,7 +18,7 @@ export interface LangiumTypeCreator { // TODO Registry instead?
      */
     onInitialize(): void;
 
-    /** React on updates of the AST in order to add/remove corresponding types from the type system, e.g. user-definied functions. */
+    /** React on updates of the AST in order to add/remove corresponding types from the type system, e.g. user-defined functions. */
     onNewAstNode(domainElement: unknown): void;
 }
 

--- a/packages/typir/src/kinds/bottom/bottom-kind.ts
+++ b/packages/typir/src/kinds/bottom/bottom-kind.ts
@@ -11,7 +11,7 @@ import { BottomType } from './bottom-type.js';
 import { isKind, Kind } from '../kind.js';
 
 export interface BottomTypeDetails {
-    /** In case of multiple inference rules, later rules are not evaluated anymore, if an earler rule already matched. */
+    /** In case of multiple inference rules, later rules are not evaluated anymore, if an earlier rule already matched. */
     inferenceRules?: InferBottomType | InferBottomType[]
 }
 

--- a/packages/typir/src/kinds/primitive/primitive-kind.ts
+++ b/packages/typir/src/kinds/primitive/primitive-kind.ts
@@ -12,7 +12,7 @@ import { PrimitiveType } from './primitive-type.js';
 
 export interface PrimitiveTypeDetails {
     primitiveName: string;
-    /** In case of multiple inference rules, later rules are not evaluated anymore, if an earler rule already matched. */
+    /** In case of multiple inference rules, later rules are not evaluated anymore, if an earlier rule already matched. */
     inferenceRules?: InferPrimitiveType | InferPrimitiveType[];
 }
 

--- a/packages/typir/src/kinds/top/top-kind.ts
+++ b/packages/typir/src/kinds/top/top-kind.ts
@@ -11,7 +11,7 @@ import { isKind, Kind } from '../kind.js';
 import { TopType } from './top-type.js';
 
 export interface TopTypeDetails {
-    /** In case of multiple inference rules, later rules are not evaluated anymore, if an earler rule already matched. */
+    /** In case of multiple inference rules, later rules are not evaluated anymore, if an earlier rule already matched. */
     inferenceRules?: InferTopType | InferTopType[]
 }
 


### PR DESCRIPTION
I was getting errors that `AstNode` from `typir/node_modules/langium` (v3.2) is not assignable to `AstNode` from `langium`.

Also, ran `npm audit fix` and fixed 2 typos