### PR TITLE
API docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,37 @@
+name: Publish API docs
+
+permissions:
+  pages: write
+  id-token: write
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  docs:
+    name: Build and publish API docs
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Build API docs
+        run: |
+          npm ci
+          npm run build
+          npm run docs
+      - name: Upload docs artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./docs
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .vscode-test/
 coverage/
 dist/
+docs/
 bin/
 lib/
 out/

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
                 "eslint-plugin-header": "~3.1.1",
                 "fs-extra": "^11.2.0",
                 "shx": "~0.3.4",
+                "typedoc": "^0.27.5",
                 "typescript": "~5.5.4",
                 "vitest": "~2.1.2"
             },
@@ -561,6 +562,18 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/@gerrit0/mini-shiki": {
+            "version": "1.24.4",
+            "resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-1.24.4.tgz",
+            "integrity": "sha512-YEHW1QeAg6UmxEmswiQbOVEg1CW22b1XUD/lNTliOsu0LD0wqoyleFMnmbTp697QE0pcadQiR5cVtbbAPncvpw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/engine-oniguruma": "^1.24.2",
+                "@shikijs/types": "^1.24.2",
+                "@shikijs/vscode-textmate": "^9.3.1"
+            }
+        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.13.0",
             "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -857,11 +870,50 @@
                 "win32"
             ]
         },
+        "node_modules/@shikijs/engine-oniguruma": {
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-1.24.3.tgz",
+            "integrity": "sha512-iNnx950gs/5Nk+zrp1LuF+S+L7SKEhn8k9eXgFYPGhVshKppsYwRmW8tpmAMvILIMSDfrgqZ0w+3xWVQB//1Xw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/types": "1.24.3",
+                "@shikijs/vscode-textmate": "^9.3.1"
+            }
+        },
+        "node_modules/@shikijs/types": {
+            "version": "1.24.3",
+            "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-1.24.3.tgz",
+            "integrity": "sha512-FPMrJ69MNxhRtldRk69CghvaGlbbN3pKRuvko0zvbfa2dXp4pAngByToqS5OY5jvN8D7LKR4RJE8UvzlCOuViw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@shikijs/vscode-textmate": "^9.3.1",
+                "@types/hast": "^3.0.4"
+            }
+        },
+        "node_modules/@shikijs/vscode-textmate": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
+            "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
             "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
             "dev": true
+        },
+        "node_modules/@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
         },
         "node_modules/@types/node": {
             "version": "18.19.55",
@@ -871,6 +923,13 @@
             "dependencies": {
                 "undici-types": "~5.26.4"
             }
+        },
+        "node_modules/@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/vscode": {
             "version": "1.94.0",
@@ -1283,6 +1342,13 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
+        "node_modules/argparse": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+            "dev": true,
+            "license": "Python-2.0"
+        },
         "node_modules/array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -1640,6 +1706,19 @@
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "dev": true
         },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
         "node_modules/esbuild": {
             "version": "0.24.0",
             "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.24.0.tgz",
@@ -1811,12 +1890,6 @@
             "engines": {
                 "node": ">=0.4.0"
             }
-        },
-        "node_modules/eslint/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
         },
         "node_modules/eslint/node_modules/chalk": {
             "version": "4.1.2",
@@ -2469,6 +2542,16 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/linkify-it": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+            "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "uc.micro": "^2.0.0"
+            }
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2507,6 +2590,13 @@
             "integrity": "sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==",
             "dev": true
         },
+        "node_modules/lunr": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
+            "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/magic-string": {
             "version": "0.30.11",
             "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.11.tgz",
@@ -2515,6 +2605,31 @@
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.0"
             }
+        },
+        "node_modules/markdown-it": {
+            "version": "14.1.0",
+            "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+            "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^2.0.1",
+                "entities": "^4.4.0",
+                "linkify-it": "^5.0.0",
+                "mdurl": "^2.0.0",
+                "punycode.js": "^2.3.1",
+                "uc.micro": "^2.1.0"
+            },
+            "bin": {
+                "markdown-it": "bin/markdown-it.mjs"
+            }
+        },
+        "node_modules/mdurl": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+            "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
@@ -2783,6 +2898,16 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
+            "engines": {
+                "node": ">=6"
+            }
+        },
+        "node_modules/punycode.js": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+            "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+            "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -3295,6 +3420,55 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/typedoc": {
+            "version": "0.27.5",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.27.5.tgz",
+            "integrity": "sha512-x+fhKJtTg4ozXwKayh/ek4wxZQI/+2hmZUdO2i2NGDBRUflDble70z+ewHod3d4gRpXSO6fnlnjbDTnJk7HlkQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@gerrit0/mini-shiki": "^1.24.0",
+                "lunr": "^2.3.9",
+                "markdown-it": "^14.1.0",
+                "minimatch": "^9.0.5",
+                "yaml": "^2.6.1"
+            },
+            "bin": {
+                "typedoc": "bin/typedoc"
+            },
+            "engines": {
+                "node": ">= 18"
+            },
+            "peerDependencies": {
+                "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
+            }
+        },
+        "node_modules/typedoc/node_modules/brace-expansion": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^1.0.0"
+            }
+        },
+        "node_modules/typedoc/node_modules/minimatch": {
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "brace-expansion": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
         "node_modules/typescript": {
             "version": "5.5.4",
             "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
@@ -3323,6 +3497,13 @@
         "node_modules/typir-langium": {
             "resolved": "packages/typir-langium",
             "link": true
+        },
+        "node_modules/uc.micro": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+            "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/undici-types": {
             "version": "5.26.5",
@@ -4043,6 +4224,19 @@
             "dev": true,
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/yaml": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.6.1.tgz",
+            "integrity": "sha512-7r0XPzioN/Q9kXBro/XPnA6kznR73DHq+GXh5ON7ZozRO6aMjbmiBuKste2wslTFkC5d1dw0GooOCepZXJ2SAg==",
+            "dev": true,
+            "license": "ISC",
+            "bin": {
+                "yaml": "bin.mjs"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "fs-extra": "^11.2.0",
                 "shx": "~0.3.4",
                 "typedoc": "^0.27.5",
+                "typedoc-plugin-mermaid": "^1.12.0",
                 "typescript": "~5.5.4",
                 "vitest": "~2.1.2"
             },
@@ -2295,6 +2296,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/html-escaper": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-3.0.3.tgz",
+            "integrity": "sha512-RuMffC89BOWQoY0WKGpIhn5gX3iI54O6nRA0yC124NYVtzjmFWBIiFd8M0x+ZdX0P9R4lADg1mgP8C7PxGOWuQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/ignore": {
             "version": "5.3.1",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -3441,6 +3449,26 @@
             },
             "peerDependencies": {
                 "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x"
+            }
+        },
+        "node_modules/typedoc-plugin-mermaid": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/typedoc-plugin-mermaid/-/typedoc-plugin-mermaid-1.12.0.tgz",
+            "integrity": "sha512-CRjw29j0YbQEh4ygG7xeGjq8zKUikgd1BBBrW3ttzTeCPLrNKZopWFPd1/leSb9dUEJ3p9exOO84aP4CgjYp3g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "html-escaper": "^3.0.3"
+            },
+            "engines": {
+                "node": ">=16.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/kamiazya"
+            },
+            "peerDependencies": {
+                "typedoc": ">=0.23.0 || 0.24.x || 0.25.x || 0.26.x"
             }
         },
         "node_modules/typedoc/node_modules/brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
         "build": "tsc -b tsconfig.build.json && npm run build --workspaces",
         "watch": "concurrently -n typir,typir-langium,ox,lox -c blue,blue,green,green \"tsc -b tsconfig.build.json -w\" \"npm run watch --workspace=typir\" \"npm run watch --workspace=typir-langium\" \"npm run watch --workspace=examples/ox\" \"npm run watch --workspace=examples/lox\"",
         "lint": "npm run lint --workspaces",
+        "docs": "typedoc",
         "test": "vitest",
         "test:run": "vitest --run",
         "test-ui": "vitest --ui",
@@ -41,6 +42,7 @@
         "eslint-plugin-header": "~3.1.1",
         "fs-extra": "^11.2.0",
         "shx": "~0.3.4",
+        "typedoc": "^0.27.5",
         "typescript": "~5.5.4",
         "vitest": "~2.1.2"
     },

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
         "fs-extra": "^11.2.0",
         "shx": "~0.3.4",
         "typedoc": "^0.27.5",
+        "typedoc-plugin-mermaid": "^1.12.0",
         "typescript": "~5.5.4",
         "vitest": "~2.1.2"
     },

--- a/packages/typir-langium/typedoc.json
+++ b/packages/typir-langium/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["src/index.ts"]
+}

--- a/packages/typir/src/graph/type-node.ts
+++ b/packages/typir/src/graph/type-node.ts
@@ -13,14 +13,16 @@ import { TypeEdge } from './type-edge.js';
 
 /**
  * The transitions between the states of a type are depicted as state machine:
+ *
  * ```mermaid
-stateDiagram-v2
-    [*] --> Invalid
-    Invalid --> Identifiable
-    Identifiable --> Completed
-    Completed --> Invalid
-    Identifiable --> Invalid
-```
+ * stateDiagram-v2
+ *     [*] --> Invalid
+ *     Invalid --> Identifiable
+ *     Identifiable --> Completed
+ *     Completed --> Invalid
+ *     Identifiable --> Invalid
+ * ```
+ *
  * A state is 'Completed', when all its dependencies are available, i.e. the types of all its properties are available.
  * A state is 'Identifiable', when all those dependencies are available which are required to calculate the identifier of the type.
  * A state is 'Invalid' otherwise.

--- a/packages/typir/src/kinds/class/class-validation.ts
+++ b/packages/typir/src/kinds/class/class-validation.ts
@@ -83,7 +83,7 @@ export class UniqueClassValidation implements ValidationRuleWithBeforeAfter {
     }
 }
 
-interface UniqueMethodValidationEntry {
+export interface UniqueMethodValidationEntry {
     languageNode: unknown;
     classType: ClassType;
 }

--- a/packages/typir/src/kinds/function/function-initializer.ts
+++ b/packages/typir/src/kinds/function/function-initializer.ts
@@ -270,7 +270,7 @@ export class FunctionTypeInitializer<T> extends TypeInitializer<FunctionType> im
 
 }
 
-interface FunctionInferenceRules {
+export interface FunctionInferenceRules {
     inferenceForCall?: TypeInferenceRule;
     validationForCall?: ValidationRule;
     inferenceForDeclaration?: TypeInferenceRule;

--- a/packages/typir/src/kinds/function/function-kind.ts
+++ b/packages/typir/src/kinds/function/function-kind.ts
@@ -60,14 +60,14 @@ export interface CreateFunctionTypeDetails<T> extends FunctionTypeDetails {
 }
 
 /** Collects all functions with the same name */
-interface OverloadedFunctionDetails {
+export interface OverloadedFunctionDetails {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     overloadedFunctions: Array<SingleFunctionDetails<any>>;
     inference: CompositeTypeInferenceRule; // collects the inference rules for all functions with the same name
     sameOutputType: Type | undefined; // if all overloaded functions with the same name have the same output/return type, this type is remembered here
 }
 
-interface SingleFunctionDetails<T> {
+export interface SingleFunctionDetails<T> {
     functionType: FunctionType;
     inferenceRuleForCalls?: InferFunctionCall<T>;
 }

--- a/packages/typir/src/services/inference.ts
+++ b/packages/typir/src/services/inference.ts
@@ -29,7 +29,7 @@ export function isInferenceProblem(problem: unknown): problem is InferenceProble
 export type InferenceRuleNotApplicable = 'N/A'; // or 'undefined' instead?
 export const InferenceRuleNotApplicable = 'N/A'; // or 'undefined' instead?
 
-type TypeInferenceResultWithoutInferringChildren =
+export type TypeInferenceResultWithoutInferringChildren =
     /** the identified type */
     Type |
     /** 'N/A' to indicate, that the current inference rule is not applicable for the given language node at all */

--- a/packages/typir/typedoc.json
+++ b/packages/typir/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "entryPoints": ["src/index.ts"]
+}

--- a/typedoc.json
+++ b/typedoc.json
@@ -3,5 +3,6 @@
   "entryPointStrategy": "packages",
   "out": "./docs",
   "includeVersion": true,
-  "githubPages": true
+  "githubPages": true,
+  "plugin": ["typedoc-plugin-mermaid"]
 }

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,7 @@
+{
+  "entryPoints": ["packages/*"],
+  "entryPointStrategy": "packages",
+  "out": "./docs",
+  "includeVersion": true,
+  "githubPages": true
+}


### PR DESCRIPTION
Adds automatic documentation generation using [TypeDoc](https://typedoc.org/), which gets published to GitHub Pages on release (and also on manual trigger), just like in Langium.

A preview of the website can be found here for now: https://aabounegm.github.io/typir/

For it to work, the source in https://github.com/TypeFox/typir/settings/pages should be set to **GitHub Actions**