### PR TITLE
Export utilities using vitest via 'typir/test'

### DIFF
--- a/examples/lox/src/language/lox-linker.ts
+++ b/examples/lox/src/language/lox-linker.ts
@@ -5,8 +5,8 @@
  ******************************************************************************/
 
 import { AstNodeDescription, DefaultLinker, LinkingError, ReferenceInfo } from 'langium';
+import { isType } from 'typir';
 import { TypirLangiumServices } from 'typir-langium';
-import { isType } from '../../../../packages/typir/lib/graph/type-node.js';
 import { isClass, isFunctionDeclaration, isMemberCall, isMethodMember, LoxAstType } from './generated/ast.js';
 import { LoxServices } from './lox-module.js';
 

--- a/examples/lox/src/language/lox-scope.ts
+++ b/examples/lox/src/language/lox-scope.ts
@@ -5,8 +5,8 @@
  ******************************************************************************/
 
 import { AstUtils, DefaultScopeProvider, EMPTY_SCOPE, ReferenceInfo, Scope } from 'langium';
+import { isClassType } from 'typir';
 import { TypirLangiumServices } from 'typir-langium';
-import { isClassType } from '../../../../packages/typir/lib/kinds/class/class-type.js';
 import { Class, isClass, isMemberCall, LoxAstType, MemberCall } from './generated/ast.js';
 import { LoxServices } from './lox-module.js';
 import { getClassChain } from './lox-utils.js';

--- a/examples/lox/test/lox-type-checking-classes.test.ts
+++ b/examples/lox/test/lox-type-checking-classes.test.ts
@@ -5,10 +5,9 @@
  ******************************************************************************/
 
 import { AstUtils } from 'langium';
+import { isClassType, isPrimitiveType } from 'typir';
+import { expectToBeType, expectTypirTypes } from 'typir/test';
 import { describe, expect, test } from 'vitest';
-import { isClassType } from '../../../packages/typir/lib/kinds/class/class-type.js';
-import { isPrimitiveType } from '../../../packages/typir/lib/kinds/primitive/primitive-type.js';
-import { expectToBeType, expectTypirTypes } from '../../../packages/typir/lib/utils/test-utils.js';
 import { isVariableDeclaration, LoxProgram } from '../src/language/generated/ast.js';
 import { loxServices, validateLox } from './lox-type-checking-utils.js';
 

--- a/examples/lox/test/lox-type-checking-cycles.test.ts
+++ b/examples/lox/test/lox-type-checking-cycles.test.ts
@@ -4,11 +4,10 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { isClassType, isFunctionType } from 'typir';
+import { expectTypirTypes } from 'typir/test';
 import { describe, test } from 'vitest';
 import { loxServices, operatorNames, validateLox } from './lox-type-checking-utils.js';
-import { isClassType } from '../../../packages/typir/lib/kinds/class/class-type.js';
-import { expectTypirTypes } from '../../../packages/typir/lib/utils/test-utils.js';
-import { isFunctionType } from '../../../packages/typir/lib/kinds/function/function-type.js';
 
 describe('Cyclic type definitions where a Class is declared and already used', () => {
     test('Class with field of its own type', async () => {

--- a/examples/lox/test/lox-type-checking-functions.test.ts
+++ b/examples/lox/test/lox-type-checking-functions.test.ts
@@ -4,12 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { assertTrue, assertTypirType, isFunctionType, isPrimitiveType, isType } from 'typir';
+import { expectTypirTypes, } from 'typir/test';
 import { describe, expect, test } from 'vitest';
-import { isType } from '../../../packages/typir/lib/graph/type-node.js';
-import { isFunctionType } from '../../../packages/typir/lib/kinds/function/function-type.js';
-import { isPrimitiveType } from '../../../packages/typir/lib/kinds/primitive/primitive-type.js';
-import { expectTypirTypes } from '../../../packages/typir/lib/utils/test-utils.js';
-import { assertTrue, assertTypirType } from '../../../packages/typir/lib/utils/utils.js';
 import { isFunctionDeclaration, isMemberCall, LoxProgram } from '../src/language/generated/ast.js';
 import { loxServices, operatorNames, validateLox } from './lox-type-checking-utils.js';
 

--- a/examples/lox/test/lox-type-checking-method.test.ts
+++ b/examples/lox/test/lox-type-checking-method.test.ts
@@ -4,13 +4,9 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
+import { assertTrue, assertTypirType, isClassType, isFunctionType, isPrimitiveType, isType } from 'typir';
+import { expectTypirTypes } from 'typir/test';
 import { describe, expect, test } from 'vitest';
-import { isType } from '../../../packages/typir/lib/graph/type-node.js';
-import { isClassType } from '../../../packages/typir/lib/kinds/class/class-type.js';
-import { isFunctionType } from '../../../packages/typir/lib/kinds/function/function-type.js';
-import { isPrimitiveType } from '../../../packages/typir/lib/kinds/primitive/primitive-type.js';
-import { expectTypirTypes } from '../../../packages/typir/lib/utils/test-utils.js';
-import { assertTrue, assertTypirType } from '../../../packages/typir/lib/utils/utils.js';
 import { isMemberCall, isMethodMember, LoxProgram } from '../src/language/generated/ast.js';
 import { loxServices, operatorNames, validateLox } from './lox-type-checking-utils.js';
 

--- a/examples/lox/test/lox-type-checking-utils.ts
+++ b/examples/lox/test/lox-type-checking-utils.ts
@@ -6,8 +6,9 @@
 
 import { EmptyFileSystem, LangiumDocument } from 'langium';
 import { parseDocument } from 'langium/test';
-import { compareValidationIssuesStrict, expectTypirTypes, isClassType, isFunctionType } from 'typir';
+import { isClassType, isFunctionType } from 'typir';
 import { deleteAllDocuments } from 'typir-langium';
+import { compareValidationIssuesStrict, expectTypirTypes } from 'typir/test';
 import { afterEach, expect } from 'vitest';
 import type { Diagnostic } from 'vscode-languageserver-types';
 import { DiagnosticSeverity } from 'vscode-languageserver-types';

--- a/examples/ox/src/language/ox-type-checking.ts
+++ b/examples/ox/src/language/ox-type-checking.ts
@@ -5,9 +5,8 @@
 ******************************************************************************/
 
 import { AstNode, AstUtils, assertUnreachable } from 'langium';
-import { CreateParameterDetails, InferOperatorWithMultipleOperands, InferOperatorWithSingleOperand, InferenceRuleNotApplicable, NO_PARAMETER_NAME, TypirServices } from 'typir';
-import { TypirLangiumServices, LangiumTypeSystemDefinition } from 'typir-langium';
-import { ValidationProblemAcceptor } from '../../../../packages/typir/lib/services/validation.js';
+import { CreateParameterDetails, InferOperatorWithMultipleOperands, InferOperatorWithSingleOperand, InferenceRuleNotApplicable, NO_PARAMETER_NAME, TypirServices, ValidationProblemAcceptor } from 'typir';
+import { LangiumTypeSystemDefinition, TypirLangiumServices } from 'typir-langium';
 import { BinaryExpression, ForStatement, FunctionDeclaration, IfStatement, MemberCall, NumberLiteral, OxAstType, TypeReference, UnaryExpression, WhileStatement, isBinaryExpression, isBooleanLiteral, isFunctionDeclaration, isParameter, isTypeReference, isUnaryExpression, isVariableDeclaration } from './generated/ast.js';
 
 export class OxTypeSystem implements LangiumTypeSystemDefinition<OxAstType> {

--- a/examples/ox/test/ox-type-checking-utils.ts
+++ b/examples/ox/test/ox-type-checking-utils.ts
@@ -6,10 +6,10 @@
 
 import { EmptyFileSystem } from 'langium';
 import { parseDocument } from 'langium/test';
+import { isFunctionType } from 'typir';
 import { deleteAllDocuments } from 'typir-langium';
+import { compareValidationIssuesStrict, expectTypirTypes } from 'typir/test';
 import { afterEach, expect } from 'vitest';
-import { isFunctionType } from '../../../packages/typir/lib/kinds/function/function-type.js';
-import { compareValidationIssuesStrict, expectTypirTypes } from '../../../packages/typir/lib/utils/test-utils.js';
 import { createOxServices } from '../src/language/ox-module.js';
 
 export const oxServices = createOxServices(EmptyFileSystem).Ox;

--- a/packages/typir/package.json
+++ b/packages/typir/package.json
@@ -12,6 +12,10 @@
     ".": {
       "import": "./lib/index.js",
       "types": "./lib/index.d.ts"
+    },
+    "./test": {
+      "import": "./lib/index-test.js",
+      "types": "./lib/index-test.d.ts"
     }
   },
   "type": "module",

--- a/packages/typir/src/index-test.ts
+++ b/packages/typir/src/index-test.ts
@@ -1,0 +1,10 @@
+/******************************************************************************
+ * Copyright 2025 TypeFox GmbH
+ * This program and the accompanying materials are made available under the
+ * terms of the MIT License, which is available in the project root.
+ ******************************************************************************/
+
+// export all utilities which are using 'vitest' and which are not located in test/ */ but in src/ here
+// to be imported via 'typir/test' in order not to mix up production code with 'vitest' dependencies
+
+export * from './utils/test-utils.js';

--- a/packages/typir/src/index.ts
+++ b/packages/typir/src/index.ts
@@ -48,7 +48,6 @@ export * from './services/subtype.js';
 export * from './services/validation.js';
 export * from './utils/dependency-injection.js';
 export * from './utils/rule-registration.js';
-export * from './utils/test-utils.js';
 export * from './utils/utils.js';
 export * from './utils/utils-definitions.js';
 export * from './utils/utils-type-comparison.js';


### PR DESCRIPTION
Aims to fix this bug report by @montymxb 

> Seems there may be a vitest import in the src that’s being loaded up w/ the regular non-test code. This leads to an unexpected repeat crashing of the LS from what I can tell. [...] The file is in packages/typir/src/utils/test-utils.ts

Requires a patch release after merging.

For fast testing, I published `next` versions:
- https://www.npmjs.com/package/typir/v/0.3.0-next.104a0e1
- https://www.npmjs.com/package/typir-langium/v/0.3.0-next.104a0e1