### PR TITLE
docs: Fix type parameter in onNewAstNode method for MyDSLTypeSystem on typir-langium/README.md

### DIFF
--- a/packages/typir-langium/README.md
+++ b/packages/typir-langium/README.md
@@ -58,7 +58,7 @@ export class MyDSLTypeSystem implements LangiumTypeSystemDefinition<MyDSLAstType
       // define constant types and rules for conversion, inference and validation here
     }
 
-    onNewAstNode(languageNode: AstNode, typir: TypirLangiumServices<OxAstType>): void {
+    onNewAstNode(languageNode: AstNode, typir: TypirLangiumServices<MyDSLAstType>): void {
       // define types and their rules which depend on the current AST (as parsed by Langium from programs written by users of your language) here
     }
 }


### PR DESCRIPTION
The code example on the typir-langium/README.md file has a reference to the OxAstType when it should be MyDSLAstType to be consistent with the rest of the example.