### PR TITLE
Remove undeclared dependency on langium in typir

### DIFF
--- a/packages/typir/src/kinds/class/class-kind.ts
+++ b/packages/typir/src/kinds/class/class-kind.ts
@@ -4,7 +4,6 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { assertUnreachable } from 'langium';
 import { Type, TypeDetails } from '../../graph/type-node.js';
 import { TypeInitializer } from '../../initialization/type-initializer.js';
 import { TypeReference } from '../../initialization/type-reference.js';
@@ -14,7 +13,7 @@ import { ValidationRule } from '../../services/validation.js';
 import { TypirServices } from '../../typir.js';
 import { InferCurrentTypeRule, RegistrationOptions } from '../../utils/utils-definitions.js';
 import { TypeCheckStrategy } from '../../utils/utils-type-comparison.js';
-import { assertTrue, assertTypirType, toArray } from '../../utils/utils.js';
+import { assertTrue, assertTypirType, assertUnreachable, toArray } from '../../utils/utils.js';
 import { FunctionType } from '../function/function-type.js';
 import { Kind, isKind } from '../kind.js';
 import { ClassTypeInitializer } from './class-initializer.js';

--- a/packages/typir/src/services/equality.ts
+++ b/packages/typir/src/services/equality.ts
@@ -4,12 +4,12 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { assertUnreachable } from 'langium';
 import { Type } from '../graph/type-node.js';
 import { TypirServices } from '../typir.js';
 import { isSpecificTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
 import { EdgeCachingInformation, TypeRelationshipCaching } from './caching.js';
 import { TypeEdge, isTypeEdge } from '../graph/type-edge.js';
+import { assertUnreachable } from '../utils/utils.js';
 
 export interface TypeEqualityProblem extends TypirProblem {
     $problem: 'TypeEqualityProblem';

--- a/packages/typir/src/services/inference.ts
+++ b/packages/typir/src/services/inference.ts
@@ -4,12 +4,11 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { assertUnreachable } from 'langium';
 import { isType, Type } from '../graph/type-node.js';
 import { TypirServices } from '../typir.js';
 import { RuleCollectorListener, RuleOptions, RuleRegistry } from '../utils/rule-registration.js';
 import { isSpecificTypirProblem, TypirProblem } from '../utils/utils-definitions.js';
-import { removeFromArray, toArray } from '../utils/utils.js';
+import { assertUnreachable, removeFromArray, toArray } from '../utils/utils.js';
 import { LanguageNodeInferenceCaching } from './caching.js';
 
 export interface InferenceProblem<LanguageType> extends TypirProblem {

--- a/packages/typir/src/utils/utils-type-comparison.ts
+++ b/packages/typir/src/utils/utils-type-comparison.ts
@@ -4,12 +4,11 @@
  * terms of the MIT License, which is available in the project root.
  ******************************************************************************/
 
-import { assertUnreachable } from 'langium';
 import { isType, Type } from '../graph/type-node.js';
 import { Kind } from '../kinds/kind.js';
 import { InferenceProblem } from '../services/inference.js';
 import { TypirServices } from '../typir.js';
-import { assertTrue } from '../utils/utils.js';
+import { assertTrue, assertUnreachable } from '../utils/utils.js';
 import { isNameTypePair, isSpecificTypirProblem, NameTypePair, TypirProblem } from './utils-definitions.js';
 
 export type TypeCheckStrategy =


### PR DESCRIPTION
The `typir` package was relying on `assertUnreachable` from the `langium` package without declaring it as a dependency. Since Typir is intended to work as a standalone package, this implicit dependency could lead to issues.

This PR replaces the `assertUnreachable` imports with a local implementation to ensure the package remains self-contained and does not rely on undeclared external modules.