### PR TITLE
Fix rule registry mutability issue with multiple language keys

### DIFF
--- a/packages/typir/src/utils/rule-registration.ts
+++ b/packages/typir/src/utils/rule-registration.ts
@@ -103,7 +103,7 @@ export class RuleRegistry<RuleType, LanguageType> implements TypeGraphListener {
     addRule(rule: RuleType, givenOptions?: Partial<RuleOptions>): void {
         const newOptions = this.getRuleOptions(givenOptions);
         const languageKeyUndefined: boolean = newOptions.languageKey === undefined;
-        const languageKeys: string[] = toArray(newOptions.languageKey);
+        const languageKeys: string[] = toArray(newOptions.languageKey, { newArray: true });
 
         const existingOptions = this.ruleToOptions.get(rule);
         const diffOptions: RuleOptions = {


### PR DESCRIPTION
When registering rules with a `languageKey` array, the rule registry was storing the original array by reference. This led to issues when `removeRule` modified the array in place.

This behavior caused problems in contexts where rules are removed and re-registered during initialization — such as in classes or functions — because the original `languageKey` array had already been altered.

This PR resolves the issue by creating a shallow copy of the `languageKey` array during rule registration to ensure immutability and prevent side effects during rule lifecycle operations.